### PR TITLE
feat: add subtitle insertion, spacebar shortcut, fix Ctrl+Wheel zoom …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "capforge",
   "productName": "CapForge",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CapForge — Auto subtitle generator with word-by-word alignment",
   "main": "electron/main.js",
   "author": {

--- a/src/renderer/src/components/editor/SubtitleEditor.tsx
+++ b/src/renderer/src/components/editor/SubtitleEditor.tsx
@@ -8,7 +8,7 @@
  * - In edit mode: timing inputs appear for each segment
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Segment, Word, WordOverrides } from '../../types/app'
 import { WordStylePopup, type WordStyleDefaults } from './WordStylePopup'
 
@@ -21,6 +21,12 @@ interface SubtitleEditorProps {
   onBeforeEdit?: () => void
   /** Global style defaults — popup uses these to compute "hasOverride". */
   defaults: WordStyleDefaults
+  /** Insert a new manual segment at the current playback position. */
+  onAddSegment?: () => void
+  /** When set, scroll the segment with this id into view and focus its text. */
+  focusSegmentId?: string | null
+  /** Called once focus has been applied so the parent can clear the request. */
+  onFocusConsumed?: () => void
 }
 
 interface PopupState {
@@ -35,11 +41,25 @@ interface WordTimingEdit {
   wordIdx: number
 }
 
-export function SubtitleEditor({ segments, currentTime, onSeek, onChange, onBeforeEdit, defaults }: SubtitleEditorProps) {
+export function SubtitleEditor({ segments, currentTime, onSeek, onChange, onBeforeEdit, defaults, onAddSegment, focusSegmentId, onFocusConsumed }: SubtitleEditorProps) {
   const [editMode,  setEditMode]  = useState(false)
   const [popup,     setPopup]     = useState<PopupState | null>(null)
   const [hasEdits,  setHasEdits]  = useState(false)
   const [wordTimingEdit, setWordTimingEdit] = useState<WordTimingEdit | null>(null)
+
+  // When the parent asks us to focus a freshly-added segment, ensure edit mode
+  // is on so the contentEditable is rendered and typeable.
+  useEffect(() => {
+    if (focusSegmentId) setEditMode(true)
+  }, [focusSegmentId])
+
+  // Toolbar handler — turns on edit mode so the user can type immediately,
+  // then asks the parent to insert a new segment at the current playback time.
+  const handleAddClick = useCallback(() => {
+    if (!onAddSegment) return
+    setEditMode(true)
+    onAddSegment()
+  }, [onAddSegment])
 
   // Active segment index (for highlight)
   const activeSegIdx = useMemo(() => {
@@ -118,9 +138,12 @@ export function SubtitleEditor({ segments, currentTime, onSeek, onChange, onBefo
       if (i < seg.words.length) {
         return { ...seg.words[i], word }
       }
-      // Extra words — reuse last word's timing
+      // Extra words — reuse last word's timing, or fall back to the segment's
+      // own bounds when the segment had no per-word timing yet (e.g. a manual
+      // sentence the user just inserted).
       const last = seg.words[seg.words.length - 1]
-      return { ...last, word }
+      if (last) return { ...last, word }
+      return { word, start: seg.start, end: seg.end }
     })
     const next = segments.map((s, si) =>
       si !== segIdx ? s : { ...s, text: newText, words: newWords }
@@ -162,6 +185,15 @@ export function SubtitleEditor({ segments, currentTime, onSeek, onChange, onBefo
         {hasEdits && editMode && (
           <span className="text-xs text-[var(--color-warning)]">Click outside a field or press Done to save</span>
         )}
+        {onAddSegment && (
+          <button
+            className="ml-auto text-xs px-2.5 py-1 rounded transition-colors border border-[var(--color-border)] text-[var(--color-text-muted)] hover:bg-white/[0.04] hover:text-[var(--color-text)]"
+            onClick={handleAddClick}
+            title="Insert a new subtitle at the current playback time"
+          >
+            + Add subtitle
+          </button>
+        )}
       </div>
 
       {/* Segment list */}
@@ -181,6 +213,8 @@ export function SubtitleEditor({ segments, currentTime, onSeek, onChange, onBefo
             wordTimingEdit={wordTimingEdit}
             onWordTimingEditToggle={setWordTimingEdit}
             onWordTimingChange={handleWordTimingChange}
+            shouldFocus={focusSegmentId === seg.id}
+            onFocusConsumed={onFocusConsumed}
           />
         ))}
       </div>
@@ -216,11 +250,29 @@ interface SegmentRowProps {
   wordTimingEdit: WordTimingEdit | null
   onWordTimingEditToggle: (edit: WordTimingEdit | null) => void
   onWordTimingChange: (si: number, wi: number, field: 'start' | 'end', value: string) => void
+  /** When true, scroll into view and focus this row's contentEditable on mount. */
+  shouldFocus?: boolean
+  onFocusConsumed?: () => void
 }
 
-function SegmentRow({ seg, segIdx, isActive, editMode, onSeek, onWordClick, onWordContextMenu, onTimingChange, onTextEdit, wordTimingEdit, onWordTimingEditToggle, onWordTimingChange }: SegmentRowProps) {
+function SegmentRow({ seg, segIdx, isActive, editMode, onSeek, onWordClick, onWordContextMenu, onTimingChange, onTextEdit, wordTimingEdit, onWordTimingEditToggle, onWordTimingChange, shouldFocus, onFocusConsumed }: SegmentRowProps) {
+  const rowRef = useRef<HTMLDivElement>(null)
+  const textRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!shouldFocus) return
+    // Wait one frame so contentEditable has rendered (edit mode just turned on).
+    const id = requestAnimationFrame(() => {
+      rowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      textRef.current?.focus()
+      onFocusConsumed?.()
+    })
+    return () => cancelAnimationFrame(id)
+  }, [shouldFocus, onFocusConsumed])
+
   return (
     <div
+      ref={rowRef}
       className={[
         'rounded-lg border transition-colors p-2.5 text-sm',
         isActive
@@ -250,7 +302,8 @@ function SegmentRow({ seg, segIdx, isActive, editMode, onSeek, onWordClick, onWo
           <div className="flex-1 min-w-0 flex flex-col gap-1.5">
             {/* Editable text */}
             <div
-              className="text-sm leading-relaxed px-1 py-0.5 rounded border border-transparent focus:border-[var(--color-accent)] focus:outline-none bg-[var(--color-surface)]"
+              ref={textRef}
+              className="text-sm leading-relaxed px-1 py-0.5 rounded border border-transparent focus:border-[var(--color-accent)] focus:outline-none bg-[var(--color-surface)] min-h-[1.5em]"
               contentEditable
               suppressContentEditableWarning
               spellCheck

--- a/src/renderer/src/components/player/AudioPlayer.tsx
+++ b/src/renderer/src/components/player/AudioPlayer.tsx
@@ -21,6 +21,7 @@ export interface AudioPlayerHandle {
   seekRelative: (dt: number) => void
   seekToTime: (t: number) => void
   playPause: () => void
+  getDuration: () => number
 }
 
 interface AudioPlayerProps {
@@ -80,6 +81,7 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
     },
     seekToTime: (t: number) => wsSeekTo(t),
     playPause,
+    getDuration: () => duration,
   }), [currentTime, duration, wsSeekTo, playPause])
 
   // Respond to external seekTo prop (driven by SubtitleEditor word click)

--- a/src/renderer/src/components/screens/ResultsScreen.tsx
+++ b/src/renderer/src/components/screens/ResultsScreen.tsx
@@ -55,6 +55,9 @@ export function ResultsScreen({ result, settings, onGroupsUpdate, projectIORef }
   // True once the user edits segments (text, timing, etc.) — ensures the
   // re-derived groups are still sent to the backend for rendering.
   const [segmentsEdited, setSegmentsEdited] = useState(false)
+  // Transient: when set, SubtitleEditor scrolls/focuses that segment's text
+  // field (used right after a manual "+ Add subtitle" so the user can type).
+  const [focusSegmentId, setFocusSegmentId] = useState<string | null>(null)
 
   const playerRef = useRef<AudioPlayerHandle>(null)
 
@@ -127,6 +130,8 @@ export function ResultsScreen({ result, settings, onGroupsUpdate, projectIORef }
       if (!p) return
 
       switch (e.key) {
+        case ' ':
+        case 'Spacebar':    e.preventDefault(); p.playPause(); break
         case 'j': case 'J': e.preventDefault(); p.seekRelative(-2); break
         case 'k': case 'K': e.preventDefault(); p.playPause(); break
         case 'l': case 'L': e.preventDefault(); p.seekRelative(2); break
@@ -188,6 +193,27 @@ export function ResultsScreen({ result, settings, onGroupsUpdate, projectIORef }
   }, [])
 
   const handleSeekDone = useCallback(() => setSeekTarget(null), [])
+
+  // Insert a new manual segment at the current playback position. Used when
+  // Whisper missed a sentence — the user adds it back by hand.
+  const handleAddSegment = useCallback(() => {
+    const start = Math.max(0, currentTime)
+    const dur = playerRef.current?.getDuration() ?? 0
+    const tentativeEnd = start + 2.0
+    const end = dur > 0 ? Math.min(tentativeEnd, dur) : tentativeEnd
+    const newSeg: Segment = {
+      id: `manual-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      start,
+      end,
+      text: '',
+      words: [],
+    }
+    pushUndo()
+    setSegments(prev => [...prev, newSeg].sort((a, b) => a.start - b.start))
+    setSegmentsEdited(true)
+    setView('text')
+    setFocusSegmentId(newSeg.id)
+  }, [currentTime, pushUndo])
 
   // Timeline edge-drag: adjust a group's start or end time.
   const handleSegmentEdge = useCallback((segId: string, edge: 'start' | 'end', newTime: number) => {
@@ -256,6 +282,9 @@ export function ResultsScreen({ result, settings, onGroupsUpdate, projectIORef }
           onChange={(next: Segment[]) => { setSegments(next); setSegmentsEdited(true) }}
           onBeforeEdit={pushUndo}
           defaults={wordStyleDefaults}
+          onAddSegment={handleAddSegment}
+          focusSegmentId={focusSegmentId}
+          onFocusConsumed={() => setFocusSegmentId(null)}
         />
       ) : (
         <GroupEditor

--- a/src/renderer/src/hooks/useVideoZoom.ts
+++ b/src/renderer/src/hooks/useVideoZoom.ts
@@ -8,7 +8,7 @@
  * - current zoom level for the label
  */
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const VZ_MIN = 1
 const VZ_MAX = 6
@@ -57,16 +57,25 @@ export function useVideoZoom() {
   }, [clampPan])
 
   // ── Ctrl+Wheel zoom ──────────────────────────────────────────
-  const onWheel = useCallback((e: React.WheelEvent) => {
-    if (!e.ctrlKey) return
-    e.preventDefault()
-    e.stopPropagation()
-    const rect = wrapRef.current?.getBoundingClientRect()
-    if (!rect) return
-    const cx = e.clientX - rect.left
-    const cy = e.clientY - rect.top
-    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15
-    zoomAt(cx, cy, factor)
+  // React registers onWheel as passive by default, which silently prevents
+  // e.preventDefault() from stopping the page scroll. We attach directly to
+  // the DOM element with { passive: false } so preventDefault works.
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    function handleWheel(e: WheelEvent) {
+      if (!e.ctrlKey) return
+      e.preventDefault()
+      e.stopPropagation()
+      const rect = wrapRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const cx = e.clientX - rect.left
+      const cy = e.clientY - rect.top
+      const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15
+      zoomAt(cx, cy, factor)
+    }
+    el.addEventListener('wheel', handleWheel, { passive: false })
+    return () => el.removeEventListener('wheel', handleWheel)
   }, [zoomAt])
 
   // ── Drag to pan ──────────────────────────────────────────────
@@ -135,6 +144,6 @@ export function useVideoZoom() {
     zoomIn,
     zoomOut,
     zoomReset,
-    handlers: { onWheel, onMouseDown, onMouseMove, onMouseUp, onDoubleClick },
+    handlers: { onMouseDown, onMouseMove, onMouseUp, onDoubleClick },
   }
 }


### PR DESCRIPTION
…(v1.1.0)

- SubtitleEditor: new "+ Add subtitle" button inserts a segment at the current playback time, auto-enters edit mode, and focuses the new text field so the user can type immediately; handles segments with no per-word timing (manual entries)
- AudioPlayer: expose getDuration() on the imperative handle
- ResultsScreen: handleAddSegment with sorted insert + undo support; add spacebar as playPause shortcut alongside k/K
- useVideoZoom: fix Ctrl+Wheel zoom — React passive wheel listener silently blocks preventDefault; switch to native addEventListener with passive:false so the browser actually suppresses page scroll
- Bump version to 1.1.0