### PR TITLE
Fix Lithuanian WhisperX alignment support

### DIFF
--- a/THIRD_PARTY_MODELS.md
+++ b/THIRD_PARTY_MODELS.md
@@ -6,11 +6,19 @@ needs them. The weights are not part of this repository.
 ## Lithuanian WhisperX alignment
 
 - Model: [`m3hrdadfi/wav2vec2-large-xlsr-lithuanian`](https://huggingface.co/m3hrdadfi/wav2vec2-large-xlsr-lithuanian)
+- Revision: `d5b27b07dceb75975ccb840370181ff02edc4c90` (pinned; verified
+  2026-07-19)
 - Purpose: Lithuanian CTC forced alignment for word-level timings
 - Architecture: `Wav2Vec2ForCTC` with `Wav2Vec2Processor`, compatible with
   WhisperX's custom `model_name` alignment-model loader
 - Training data: Mozilla Common Voice Lithuanian
 - License: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- Download size: approximately 1.2 GB on first use
+
+CapForge resolves the pinned revision to a local Hugging Face snapshot before
+passing it to WhisperX. Pinning is security-critical because this model uses a
+pickle-format `pytorch_model.bin`, which can execute code while loading; an
+unpinned upstream change must never be accepted silently.
 
 Apache-2.0 permits use, modification, and distribution alongside CapForge's
 MIT-licensed code. If CapForge begins redistributing the model weights instead

--- a/THIRD_PARTY_MODELS.md
+++ b/THIRD_PARTY_MODELS.md
@@ -1,0 +1,18 @@
+# Third-party models
+
+CapForge downloads model weights from their publishers when a feature first
+needs them. The weights are not part of this repository.
+
+## Lithuanian WhisperX alignment
+
+- Model: [`m3hrdadfi/wav2vec2-large-xlsr-lithuanian`](https://huggingface.co/m3hrdadfi/wav2vec2-large-xlsr-lithuanian)
+- Purpose: Lithuanian CTC forced alignment for word-level timings
+- Architecture: `Wav2Vec2ForCTC` with `Wav2Vec2Processor`, compatible with
+  WhisperX's custom `model_name` alignment-model loader
+- Training data: Mozilla Common Voice Lithuanian
+- License: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+Apache-2.0 permits use, modification, and distribution alongside CapForge's
+MIT-licensed code. If CapForge begins redistributing the model weights instead
+of downloading them on demand, the Apache-2.0 license and any applicable
+notices must be included with that distribution.

--- a/backend/engine/transcriber.py
+++ b/backend/engine/transcriber.py
@@ -17,6 +17,7 @@ from backend.models.schemas import (
     JobStatus,
     ModelSize,
     ProgressUpdate,
+    RealignResponse,
     Segment,
     TranscribeRequest,
     TranscriptionResult,
@@ -108,6 +109,7 @@ class Transcriber:
         self._check_cancelled()
         self._report(on_progress, JobStatus.ALIGNING, 55, "Loading alignment model…")
         model_a = None
+        alignment_degraded = False
         try:
             model_a, metadata = self._load_alignment_model(detected_language, device)
             self._report(on_progress, JobStatus.ALIGNING, 60, "Aligning words…")
@@ -117,6 +119,7 @@ class Transcriber:
             )
             self._report(on_progress, JobStatus.ALIGNING, 75, "Word alignment complete")
         except Exception as exc:
+            alignment_degraded = True
             warning = (
                 f"Forced alignment unavailable for language {detected_language!r}: "
                 f"{exc}. Preserving the transcription with approximate word timings."
@@ -152,7 +155,12 @@ class Transcriber:
 
         # --- Build result ---
         self._report(on_progress, JobStatus.DONE, 95, "Building result…")
-        transcription = self._build_result(result, detected_language, audio_path)
+        transcription = self._build_result(
+            result,
+            detected_language,
+            audio_path,
+            alignment_degraded=alignment_degraded,
+        )
         self._report(on_progress, JobStatus.DONE, 100, "Done")
         return transcription
 
@@ -176,13 +184,13 @@ class Transcriber:
 
     def realign_segments(
         self, segments: list[Segment], audio_path: str, language: str
-    ) -> list[Segment]:
+    ) -> RealignResponse:
         """Re-run WhisperX forced alignment on edited segments.
 
         Used after the user edits a segment's text so every word gets a real
         timestamp instead of one inherited from its neighbor. Returns new
-        Segment objects (1:1 with the input) and never touches the stored
-        transcription result.
+        Segment objects (1:1 with the input) plus whether approximate timings
+        had to be used, and never touches the stored transcription result.
         """
         if not Path(audio_path).is_file():
             raise FileNotFoundError(f"Audio file not found: {audio_path}")
@@ -190,8 +198,6 @@ class Transcriber:
         device = self._device or detect_hardware().recommended_device.value
         try:
             self._load_align_model(language, device)
-            audio = whisperx.load_audio(audio_path)
-            return [self._realign_one(seg, audio, device) for seg in segments]
         except Exception as exc:
             logger.warning(
                 "Forced alignment unavailable for language %r during caption "
@@ -200,12 +206,32 @@ class Transcriber:
                 exc,
                 exc_info=True,
             )
-            return [self._approximate_segment_words(seg) for seg in segments]
+            return RealignResponse(
+                segments=[self._approximate_segment_words(seg) for seg in segments],
+                alignment_degraded=True,
+            )
 
-    def _realign_one(self, seg: Segment, audio: Any, device: str) -> Segment:
+        # Only an unavailable alignment model is recoverable. Audio decoding
+        # and alignment errors are real failures and must reach the endpoint's
+        # 500 handler instead of being disguised as successful approximate data.
+        audio = whisperx.load_audio(audio_path)
+        aligned_segments: list[Segment] = []
+        alignment_degraded = False
+        for segment in segments:
+            aligned, segment_degraded = self._realign_one(segment, audio, device)
+            aligned_segments.append(aligned)
+            alignment_degraded = alignment_degraded or segment_degraded
+        return RealignResponse(
+            segments=aligned_segments,
+            alignment_degraded=alignment_degraded,
+        )
+
+    def _realign_one(
+        self, seg: Segment, audio: Any, device: str
+    ) -> tuple[Segment, bool]:
         text = seg.text.strip()
         if not text or seg.end <= seg.start:
-            return seg
+            return seg, False
 
         result = whisperx.align(
             [{"start": seg.start, "end": seg.end, "text": text}],
@@ -217,18 +243,25 @@ class Transcriber:
         raw_words: list[dict] = []
         for sub in result.get("segments", []):
             raw_words.extend(sub.get("words", []))
+        alignment_degraded = not raw_words or any(
+            word.get("start") is None or word.get("end") is None
+            for word in raw_words
+        )
         if not raw_words:
             # Alignment failed outright (e.g. no dictionary characters) —
             # distribute the words evenly across the original window.
             raw_words = [{"word": w} for w in text.split()]
 
         words = self._fill_word_timings(raw_words, seg.start, seg.end)
-        return Segment(
-            start=words[0].start if words else seg.start,
-            end=words[-1].end if words else seg.end,
-            text=seg.text,
-            words=words,
-            speaker=seg.speaker,
+        return (
+            Segment(
+                start=words[0].start if words else seg.start,
+                end=words[-1].end if words else seg.end,
+                text=seg.text,
+                words=words,
+                speaker=seg.speaker,
+            ),
+            alignment_degraded,
         )
 
     # --- Private helpers ---
@@ -407,7 +440,10 @@ class Transcriber:
 
     @staticmethod
     def _build_result(
-        raw: dict, language: Optional[str], audio_path: str
+        raw: dict,
+        language: Optional[str],
+        audio_path: str,
+        alignment_degraded: bool = False,
     ) -> TranscriptionResult:
         segments: list[Segment] = []
         for seg in raw.get("segments", []):
@@ -452,6 +488,7 @@ class Transcriber:
             language=language,
             audio_path=audio_path,
             duration=media_duration,
+            alignment_degraded=alignment_degraded,
         )
 
     @staticmethod

--- a/backend/engine/transcriber.py
+++ b/backend/engine/transcriber.py
@@ -31,6 +31,13 @@ logger = logging.getLogger(__name__)
 # can't silently swap the model.
 DIARIZATION_MODEL = "pyannote/speaker-diarization-community-1"
 
+# WhisperX does not provide defaults for every language. Keep CapForge's
+# additions in one place so transcription and edited-caption realignment use
+# exactly the same model selection.
+ALIGNMENT_MODELS: dict[str, str] = {
+    "lt": "m3hrdadfi/wav2vec2-large-xlsr-lithuanian",
+}
+
 # Callback type for progress reporting
 ProgressCallback = Optional[Callable[[ProgressUpdate], Any]]
 
@@ -100,20 +107,28 @@ class Transcriber:
         # --- Step 3: Align ---
         self._check_cancelled()
         self._report(on_progress, JobStatus.ALIGNING, 55, "Loading alignment model…")
-        model_a, metadata = whisperx.load_align_model(
-            language_code=detected_language, device=device
-        )
-        self._report(on_progress, JobStatus.ALIGNING, 60, "Aligning words…")
-        result = whisperx.align(
-            result["segments"], model_a, metadata, audio, device,
-            return_char_alignments=False,
-        )
-        self._report(on_progress, JobStatus.ALIGNING, 75, "Word alignment complete")
-
-        # Free alignment model
-        del model_a
-        gc.collect()
-        self._try_cuda_empty_cache()
+        model_a = None
+        try:
+            model_a, metadata = self._load_alignment_model(detected_language, device)
+            self._report(on_progress, JobStatus.ALIGNING, 60, "Aligning words…")
+            result = whisperx.align(
+                result["segments"], model_a, metadata, audio, device,
+                return_char_alignments=False,
+            )
+            self._report(on_progress, JobStatus.ALIGNING, 75, "Word alignment complete")
+        except Exception as exc:
+            warning = (
+                f"Forced alignment unavailable for language {detected_language!r}: "
+                f"{exc}. Preserving the transcription with approximate word timings."
+            )
+            logger.warning(warning, exc_info=True)
+            self._report(on_progress, JobStatus.ALIGNING, 75, f"Warning: {warning}")
+            result = self._add_approximate_word_timings(result)
+        finally:
+            if model_a is not None:
+                del model_a
+                gc.collect()
+                self._try_cuda_empty_cache()
 
         # --- Step 4: Diarize (optional) ---
         self._check_cancelled()
@@ -173,9 +188,19 @@ class Transcriber:
             raise FileNotFoundError(f"Audio file not found: {audio_path}")
 
         device = self._device or detect_hardware().recommended_device.value
-        self._load_align_model(language, device)
-        audio = whisperx.load_audio(audio_path)
-        return [self._realign_one(seg, audio, device) for seg in segments]
+        try:
+            self._load_align_model(language, device)
+            audio = whisperx.load_audio(audio_path)
+            return [self._realign_one(seg, audio, device) for seg in segments]
+        except Exception as exc:
+            logger.warning(
+                "Forced alignment unavailable for language %r during caption "
+                "realignment: %s. Returning approximate word timings.",
+                language,
+                exc,
+                exc_info=True,
+            )
+            return [self._approximate_segment_words(seg) for seg in segments]
 
     def _realign_one(self, seg: Segment, audio: Any, device: str) -> Segment:
         text = seg.text.strip()
@@ -265,7 +290,8 @@ class Transcriber:
         self._model_size = model_size
 
     def _load_align_model(self, language: str, device: str) -> None:
-        if self._align_model is not None and self._align_lang == language:
+        normalized_language = language.lower()
+        if self._align_model is not None and self._align_lang == normalized_language:
             return
         if self._align_model is not None:
             del self._align_model
@@ -274,12 +300,58 @@ class Transcriber:
             self._align_lang = None
             gc.collect()
             self._try_cuda_empty_cache()
-        model_a, metadata = whisperx.load_align_model(
-            language_code=language, device=device
-        )
+        model_a, metadata = self._load_alignment_model(normalized_language, device)
         self._align_model = model_a
         self._align_metadata = metadata
-        self._align_lang = language
+        self._align_lang = normalized_language
+
+    @staticmethod
+    def _load_alignment_model(language: Optional[str], device: str) -> tuple[Any, dict]:
+        """Load CapForge's configured aligner or defer to WhisperX's default."""
+        normalized_language = language.lower() if language else language
+        kwargs: dict[str, Any] = {
+            "language_code": normalized_language,
+            "device": device,
+        }
+        model_name = ALIGNMENT_MODELS.get(normalized_language or "")
+        if model_name:
+            kwargs["model_name"] = model_name
+        return whisperx.load_align_model(**kwargs)
+
+    @classmethod
+    def _add_approximate_word_timings(cls, raw: dict) -> dict:
+        """Copy a Whisper result and add evenly distributed word timings."""
+        result = dict(raw)
+        result["segments"] = []
+        for raw_segment in raw.get("segments", []):
+            segment = dict(raw_segment)
+            start = float(segment.get("start", 0.0))
+            end = float(segment.get("end", start))
+            words = cls._fill_word_timings(
+                [{"word": word} for word in segment.get("text", "").split()],
+                start,
+                end,
+            )
+            segment["words"] = [word.model_dump(exclude_none=True) for word in words]
+            result["segments"].append(segment)
+        return result
+
+    @classmethod
+    def _approximate_segment_words(cls, seg: Segment) -> Segment:
+        """Return an edited segment with evenly distributed word timings."""
+        text = seg.text.strip()
+        if not text or seg.end <= seg.start:
+            return seg
+        words = cls._fill_word_timings(
+            [{"word": word} for word in text.split()], seg.start, seg.end
+        )
+        return Segment(
+            start=seg.start,
+            end=seg.end,
+            text=seg.text,
+            words=words,
+            speaker=seg.speaker,
+        )
 
     @staticmethod
     def _fill_word_timings(

--- a/backend/engine/transcriber.py
+++ b/backend/engine/transcriber.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 import whisperx
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import LocalEntryNotFoundError
 
 from backend.engine.hardware import detect_hardware
 from backend.models.schemas import (
@@ -35,8 +37,14 @@ DIARIZATION_MODEL = "pyannote/speaker-diarization-community-1"
 # WhisperX does not provide defaults for every language. Keep CapForge's
 # additions in one place so transcription and edited-caption realignment use
 # exactly the same model selection.
-ALIGNMENT_MODELS: dict[str, str] = {
-    "lt": "m3hrdadfi/wav2vec2-large-xlsr-lithuanian",
+ALIGNMENT_MODELS: dict[str, tuple[str, str]] = {
+    # (repo_id, pinned revision) — verified 2026-07-19; upstream has been
+    # unchanged since 2021-11-04. The pin is security-critical because this
+    # repository currently distributes pickle weights rather than safetensors.
+    "lt": (
+        "m3hrdadfi/wav2vec2-large-xlsr-lithuanian",
+        "d5b27b07dceb75975ccb840370181ff02edc4c90",
+    ),
 }
 
 # Callback type for progress reporting
@@ -111,7 +119,9 @@ class Transcriber:
         model_a = None
         alignment_degraded = False
         try:
-            model_a, metadata = self._load_alignment_model(detected_language, device)
+            model_a, metadata = self._load_alignment_model(
+                detected_language, device, on_progress
+            )
             self._report(on_progress, JobStatus.ALIGNING, 60, "Aligning words…")
             result = whisperx.align(
                 result["segments"], model_a, metadata, audio, device,
@@ -338,17 +348,38 @@ class Transcriber:
         self._align_metadata = metadata
         self._align_lang = normalized_language
 
-    @staticmethod
-    def _load_alignment_model(language: Optional[str], device: str) -> tuple[Any, dict]:
+    @classmethod
+    def _load_alignment_model(
+        cls,
+        language: Optional[str],
+        device: str,
+        on_progress: ProgressCallback = None,
+    ) -> tuple[Any, dict]:
         """Load CapForge's configured aligner or defer to WhisperX's default."""
         normalized_language = language.lower() if language else language
         kwargs: dict[str, Any] = {
             "language_code": normalized_language,
             "device": device,
         }
-        model_name = ALIGNMENT_MODELS.get(normalized_language or "")
-        if model_name:
-            kwargs["model_name"] = model_name
+        model_config = ALIGNMENT_MODELS.get(normalized_language or "")
+        if model_config:
+            repo_id, revision = model_config
+            try:
+                model_path = snapshot_download(
+                    repo_id,
+                    revision=revision,
+                    local_files_only=True,
+                )
+            except LocalEntryNotFoundError:
+                cls._report(
+                    on_progress,
+                    JobStatus.ALIGNING,
+                    55,
+                    "Downloading Lithuanian alignment model from Hugging Face "
+                    "(one-time, ~1.2 GB)…",
+                )
+                model_path = snapshot_download(repo_id, revision=revision)
+            kwargs["model_name"] = model_path
         return whisperx.load_align_model(**kwargs)
 
     @classmethod

--- a/backend/exporters/premiere_export.py
+++ b/backend/exporters/premiere_export.py
@@ -22,6 +22,7 @@ def export_subforge(result: TranscriptionResult) -> str:
             "language": result.language,
             "audio_path": result.audio_path,
             "duration": result.duration,
+            "alignment_degraded": result.alignment_degraded,
         },
         "segments": [],
     }

--- a/backend/main.py
+++ b/backend/main.py
@@ -610,7 +610,7 @@ async def realign_segments(request: RealignRequest) -> RealignResponse:
 
     loop = asyncio.get_running_loop()
     try:
-        segments = await loop.run_in_executor(
+        outcome = await loop.run_in_executor(
             None,
             lambda: transcriber.realign_segments(request.segments, audio_path, language),
         )
@@ -621,7 +621,11 @@ async def realign_segments(request: RealignRequest) -> RealignResponse:
             status_code=500,
             detail={"title": friendly.title, "hint": friendly.hint, "raw": str(e)},
         )
-    return RealignResponse(segments=segments)
+    if outcome.alignment_degraded:
+        # Preserve this warning on the stored result so GET /api/result,
+        # reconnect resync, JSON export, and project saves can surface it.
+        current_result.alignment_degraded = True
+    return outcome
 
 
 # --- Agent endpoints (token-guarded; drive the live UI) ---

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -96,6 +96,7 @@ class TranscriptionResult(BaseModel):
     language: Optional[str] = None
     audio_path: str = ""
     duration: Optional[float] = None
+    alignment_degraded: bool = False
 
 
 class RealignRequest(BaseModel):
@@ -108,6 +109,7 @@ class RealignRequest(BaseModel):
 
 class RealignResponse(BaseModel):
     segments: list[Segment] = Field(default_factory=list)
+    alignment_degraded: bool = False
 
 
 # --- Progress ---

--- a/backend/tests/test_realign.py
+++ b/backend/tests/test_realign.py
@@ -25,7 +25,25 @@ def _install_fake_whisperx() -> types.ModuleType:
     return fake
 
 
+def _install_fake_huggingface_hub() -> None:
+    """Stub the transitive dependency so this test module stays lightweight."""
+    if "huggingface_hub" in sys.modules:
+        return
+
+    fake_hub = types.ModuleType("huggingface_hub")
+    fake_errors = types.ModuleType("huggingface_hub.errors")
+
+    class FakeLocalEntryNotFoundError(Exception):
+        pass
+
+    fake_hub.snapshot_download = lambda *args, **kwargs: "/hf-cache/default"
+    fake_errors.LocalEntryNotFoundError = FakeLocalEntryNotFoundError
+    sys.modules["huggingface_hub"] = fake_hub
+    sys.modules["huggingface_hub.errors"] = fake_errors
+
+
 FAKE_WX = _install_fake_whisperx()
+_install_fake_huggingface_hub()
 
 import backend.engine.transcriber as transcriber_module  # noqa: E402
 from backend.engine.transcriber import ALIGNMENT_MODELS, Transcriber  # noqa: E402

--- a/backend/tests/test_realign.py
+++ b/backend/tests/test_realign.py
@@ -27,11 +27,14 @@ def _install_fake_whisperx() -> types.ModuleType:
 
 FAKE_WX = _install_fake_whisperx()
 
-from backend.engine.transcriber import Transcriber  # noqa: E402
+import backend.engine.transcriber as transcriber_module  # noqa: E402
+from backend.engine.transcriber import ALIGNMENT_MODELS, Transcriber  # noqa: E402
 from backend.models.schemas import (  # noqa: E402
     JobStatus,
     ProgressUpdate,
     Segment,
+    SystemInfo,
+    TranscribeRequest,
     TranscriptionResult,
     WordSegment,
 )
@@ -224,6 +227,109 @@ def test_align_model_cached_per_language(monkeypatch, audio_file):
     t.unload_model()
     t.realign_segments([seg], audio_file, "de")
     assert loads == ["en", "de", "de"]  # unload cleared the cache
+
+
+def test_lithuanian_selects_configured_alignment_model(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_load(**kwargs):
+        calls.append(kwargs)
+        return "MODEL", {}
+
+    monkeypatch.setattr(FAKE_WX, "load_align_model", fake_load)
+    Transcriber._load_alignment_model("lt", "cpu")
+
+    assert calls == [{
+        "language_code": "lt",
+        "device": "cpu",
+        "model_name": ALIGNMENT_MODELS["lt"],
+    }]
+
+
+def test_english_uses_whisperx_default_alignment_model(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_load(**kwargs):
+        calls.append(kwargs)
+        return "MODEL", {}
+
+    monkeypatch.setattr(FAKE_WX, "load_align_model", fake_load)
+    Transcriber._load_alignment_model("en", "cpu")
+
+    assert calls == [{"language_code": "en", "device": "cpu"}]
+
+
+def test_alignment_load_failure_preserves_transcription_with_approximate_words(
+    monkeypatch, audio_file
+):
+    class FakeWhisperModel:
+        def transcribe(self, audio, **kwargs):
+            return {
+                "language": "lt",
+                "segments": [
+                    {"start": 1.0, "end": 3.0, "text": "Labas rytas"},
+                ],
+            }
+
+    def fail_load(**kwargs):
+        raise RuntimeError("aligner download failed")
+
+    monkeypatch.setattr(FAKE_WX, "load_align_model", fail_load)
+    monkeypatch.setattr(
+        transcriber_module, "detect_hardware", lambda: SystemInfo()
+    )
+    transcriber = Transcriber()
+    transcriber._model = FakeWhisperModel()
+    monkeypatch.setattr(transcriber, "_load_model", lambda *args, **kwargs: None)
+    progress: list[ProgressUpdate] = []
+
+    result = transcriber.transcribe(
+        TranscribeRequest(audio_path=audio_file, language="lt"),
+        on_progress=progress.append,
+    )
+
+    assert result.language == "lt"
+    assert [segment.text for segment in result.segments] == ["Labas rytas"]
+    assert [word.word for word in result.segments[0].words] == ["Labas", "rytas"]
+    assert result.segments[0].words[0].start == pytest.approx(1.0)
+    assert result.segments[0].words[0].end == pytest.approx(2.0)
+    assert result.segments[0].words[1].end == pytest.approx(3.0)
+    assert any(
+        "approximate word timings" in update.message for update in progress
+    )
+
+
+def test_realign_lithuanian_uses_configured_alignment_model(
+    monkeypatch, audio_file
+):
+    calls: list[dict] = []
+
+    def fake_load(**kwargs):
+        calls.append(kwargs)
+        return "LT_MODEL", {"language": "lt"}
+
+    monkeypatch.setattr(FAKE_WX, "load_align_model", fake_load)
+    monkeypatch.setattr(
+        FAKE_WX,
+        "align",
+        lambda *args, **kwargs: {
+            "segments": [{
+                "words": [{"word": "Labas", "start": 0.0, "end": 1.0}]
+            }]
+        },
+    )
+
+    transcriber = Transcriber()
+    transcriber._device = "cpu"
+    transcriber.realign_segments(
+        [Segment(start=0.0, end=1.0, text="Labas")], audio_file, "lt"
+    )
+
+    assert calls == [{
+        "language_code": "lt",
+        "device": "cpu",
+        "model_name": ALIGNMENT_MODELS["lt"],
+    }]
 
 
 # --- POST /api/realign endpoint ---

--- a/backend/tests/test_realign.py
+++ b/backend/tests/test_realign.py
@@ -40,6 +40,19 @@ from backend.models.schemas import (  # noqa: E402
     WordSegment,
 )
 
+LT_REPO_ID, LT_REVISION = ALIGNMENT_MODELS["lt"]
+CACHED_LT_MODEL_PATH = "/hf-cache/lithuanian-alignment"
+
+
+@pytest.fixture(autouse=True)
+def _cached_lithuanian_snapshot(monkeypatch):
+    """Keep alignment tests fully offline unless a test overrides the probe."""
+    monkeypatch.setattr(
+        transcriber_module,
+        "snapshot_download",
+        lambda *args, **kwargs: CACHED_LT_MODEL_PATH,
+    )
+
 
 # --- _fill_word_timings (pure interpolation logic) ---
 
@@ -291,20 +304,56 @@ def test_align_model_cached_per_language(monkeypatch, audio_file):
 
 
 def test_lithuanian_selects_configured_alignment_model(monkeypatch):
+    assert ALIGNMENT_MODELS["lt"] == (
+        "m3hrdadfi/wav2vec2-large-xlsr-lithuanian",
+        "d5b27b07dceb75975ccb840370181ff02edc4c90",
+    )
     calls: list[dict] = []
+    snapshot_calls: list[tuple[str, str, bool]] = []
 
     def fake_load(**kwargs):
         calls.append(kwargs)
         return "MODEL", {}
 
+    def fake_snapshot(repo_id, *, revision, local_files_only=False):
+        snapshot_calls.append((repo_id, revision, local_files_only))
+        return CACHED_LT_MODEL_PATH
+
     monkeypatch.setattr(FAKE_WX, "load_align_model", fake_load)
+    monkeypatch.setattr(transcriber_module, "snapshot_download", fake_snapshot)
     Transcriber._load_alignment_model("lt", "cpu")
 
+    assert snapshot_calls == [(LT_REPO_ID, LT_REVISION, True)]
     assert calls == [{
         "language_code": "lt",
         "device": "cpu",
-        "model_name": ALIGNMENT_MODELS["lt"],
+        "model_name": CACHED_LT_MODEL_PATH,
     }]
+
+
+def test_lithuanian_cache_miss_reports_download_before_pinned_snapshot(monkeypatch):
+    snapshot_calls: list[tuple[str, str, bool]] = []
+    progress: list[ProgressUpdate] = []
+
+    def fake_snapshot(repo_id, *, revision, local_files_only=False):
+        snapshot_calls.append((repo_id, revision, local_files_only))
+        if local_files_only:
+            raise transcriber_module.LocalEntryNotFoundError("not cached")
+        return CACHED_LT_MODEL_PATH
+
+    monkeypatch.setattr(transcriber_module, "snapshot_download", fake_snapshot)
+
+    Transcriber._load_alignment_model("lt", "cpu", progress.append)
+
+    assert snapshot_calls == [
+        (LT_REPO_ID, LT_REVISION, True),
+        (LT_REPO_ID, LT_REVISION, False),
+    ]
+    assert any(
+        "Downloading Lithuanian alignment model" in update.message
+        and "~1.2 GB" in update.message
+        for update in progress
+    )
 
 
 def test_english_uses_whisperx_default_alignment_model(monkeypatch):
@@ -315,6 +364,11 @@ def test_english_uses_whisperx_default_alignment_model(monkeypatch):
         return "MODEL", {}
 
     monkeypatch.setattr(FAKE_WX, "load_align_model", fake_load)
+    monkeypatch.setattr(
+        transcriber_module,
+        "snapshot_download",
+        lambda *args, **kwargs: pytest.fail("English must not resolve a custom snapshot"),
+    )
     Transcriber._load_alignment_model("en", "cpu")
 
     assert calls == [{"language_code": "en", "device": "cpu"}]
@@ -390,7 +444,7 @@ def test_realign_lithuanian_uses_configured_alignment_model(
     assert calls == [{
         "language_code": "lt",
         "device": "cpu",
-        "model_name": ALIGNMENT_MODELS["lt"],
+        "model_name": CACHED_LT_MODEL_PATH,
     }]
 
 

--- a/backend/tests/test_realign.py
+++ b/backend/tests/test_realign.py
@@ -32,6 +32,7 @@ from backend.engine.transcriber import ALIGNMENT_MODELS, Transcriber  # noqa: E4
 from backend.models.schemas import (  # noqa: E402
     JobStatus,
     ProgressUpdate,
+    RealignResponse,
     Segment,
     SystemInfo,
     TranscribeRequest,
@@ -149,11 +150,12 @@ def test_realign_merges_subsegments_into_one(monkeypatch, audio_file):
     seg = Segment(start=0.0, end=2.0, text="Hello there. Bye.", speaker="SPEAKER_00")
     out = t.realign_segments([seg], audio_file, "en")
 
-    assert len(out) == 1
-    assert out[0].text == "Hello there. Bye."
-    assert out[0].speaker == "SPEAKER_00"
-    assert [w.word for w in out[0].words] == ["Hello", "there.", "Bye."]
-    assert out[0].start == 0.0 and out[0].end == 2.0
+    assert out.alignment_degraded is False
+    assert len(out.segments) == 1
+    assert out.segments[0].text == "Hello there. Bye."
+    assert out.segments[0].speaker == "SPEAKER_00"
+    assert [w.word for w in out.segments[0].words] == ["Hello", "there.", "Bye."]
+    assert out.segments[0].start == 0.0 and out.segments[0].end == 2.0
 
 
 def test_realign_failed_alignment_falls_back_to_even_spacing(monkeypatch, audio_file):
@@ -168,10 +170,35 @@ def test_realign_failed_alignment_falls_back_to_even_spacing(monkeypatch, audio_
     seg = Segment(start=0.0, end=2.0, text="10 45")
     out = t.realign_segments([seg], audio_file, "en")
 
-    assert [w.word for w in out[0].words] == ["10", "45"]
-    assert out[0].words[0].start == pytest.approx(0.0)
-    assert out[0].words[0].end == pytest.approx(1.0)
-    assert out[0].words[1].end == pytest.approx(2.0)
+    assert out.alignment_degraded is True
+    assert [w.word for w in out.segments[0].words] == ["10", "45"]
+    assert out.segments[0].words[0].start == pytest.approx(0.0)
+    assert out.segments[0].words[0].end == pytest.approx(1.0)
+    assert out.segments[0].words[1].end == pytest.approx(2.0)
+
+
+def test_realign_interpolated_words_are_marked_degraded(monkeypatch, audio_file):
+    monkeypatch.setattr(
+        FAKE_WX,
+        "align",
+        lambda *args, **kwargs: {
+            "segments": [{
+                "words": [
+                    {"word": "Labas", "start": 0.0, "end": 0.8},
+                    {"word": "10"},
+                ]
+            }]
+        },
+    )
+    t = Transcriber()
+
+    out = t.realign_segments(
+        [Segment(start=0.0, end=2.0, text="Labas 10")], audio_file, "lt"
+    )
+
+    assert out.alignment_degraded is True
+    assert out.segments[0].words[1].start == pytest.approx(0.8)
+    assert out.segments[0].words[1].end == pytest.approx(2.0)
 
 
 def test_realign_empty_text_returns_segment_unchanged(monkeypatch, audio_file):
@@ -182,7 +209,41 @@ def test_realign_empty_text_returns_segment_unchanged(monkeypatch, audio_file):
     t = Transcriber()
     seg = Segment(start=1.0, end=2.0, text="   ")
     out = t.realign_segments([seg], audio_file, "en")
-    assert out[0] is seg
+    assert out.alignment_degraded is False
+    assert out.segments[0] is seg
+
+
+def test_realign_model_load_failure_uses_flagged_approximate_timings(
+    monkeypatch, audio_file
+):
+    monkeypatch.setattr(
+        FAKE_WX,
+        "load_align_model",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("model unavailable")),
+    )
+    t = Transcriber()
+
+    out = t.realign_segments(
+        [Segment(start=0.0, end=2.0, text="Labas rytas")], audio_file, "lt"
+    )
+
+    assert out.alignment_degraded is True
+    assert [word.word for word in out.segments[0].words] == ["Labas", "rytas"]
+    assert out.segments[0].words[0].end == pytest.approx(1.0)
+
+
+def test_realign_alignment_error_is_not_hidden_by_fallback(monkeypatch, audio_file):
+    monkeypatch.setattr(
+        FAKE_WX,
+        "align",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("alignment bug")),
+    )
+    t = Transcriber()
+
+    with pytest.raises(RuntimeError, match="alignment bug"):
+        t.realign_segments(
+            [Segment(start=0.0, end=1.0, text="Labas")], audio_file, "lt"
+        )
 
 
 def test_realign_missing_audio_raises():
@@ -289,6 +350,7 @@ def test_alignment_load_failure_preserves_transcription_with_approximate_words(
     )
 
     assert result.language == "lt"
+    assert result.alignment_degraded is True
     assert [segment.text for segment in result.segments] == ["Labas rytas"]
     assert [word.word for word in result.segments[0].words] == ["Labas", "rytas"]
     assert result.segments[0].words[0].start == pytest.approx(1.0)
@@ -436,7 +498,7 @@ def test_endpoint_success_is_stateless(client, monkeypatch, audio_file):
 
     def fake_realign(segments, audio_path, language):
         calls.append((len(segments), audio_path, language))
-        return realigned
+        return RealignResponse(segments=realigned)
 
     monkeypatch.setattr(main_module.transcriber, "realign_segments", fake_realign)
 
@@ -448,6 +510,7 @@ def test_endpoint_success_is_stateless(client, monkeypatch, audio_file):
     )
     assert resp.status_code == 200
     body = resp.json()
+    assert body["alignment_degraded"] is False
     assert [w["word"] for w in body["segments"][0]["words"]] == ["hi", "there"]
     # Audio path came from the stored result, not the request.
     assert calls == [(1, audio_file, "en")]
@@ -463,7 +526,7 @@ def test_endpoint_language_override(client, monkeypatch, audio_file):
 
     def fake_realign(segments, audio_path, language):
         seen.append(language)
-        return segments
+        return RealignResponse(segments=segments)
 
     monkeypatch.setattr(main_module.transcriber, "realign_segments", fake_realign)
     resp = tc.post(
@@ -475,3 +538,52 @@ def test_endpoint_language_override(client, monkeypatch, audio_file):
     )
     assert resp.status_code == 200
     assert seen == ["de"]
+
+
+def test_endpoint_marks_stored_result_when_realign_is_degraded(
+    client, monkeypatch, audio_file
+):
+    tc, main_module = client
+    stored = _loaded_result(audio_file)
+    monkeypatch.setattr(main_module, "current_result", stored)
+    approximate = Segment(
+        start=0.0,
+        end=1.0,
+        text="Labas",
+        words=[WordSegment(word="Labas", start=0.0, end=1.0)],
+    )
+    monkeypatch.setattr(
+        main_module.transcriber,
+        "realign_segments",
+        lambda *args: RealignResponse(
+            segments=[approximate], alignment_degraded=True
+        ),
+    )
+
+    resp = tc.post(
+        "/api/realign",
+        json={"segments": [{"start": 0.0, "end": 1.0, "text": "Labas"}]},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["alignment_degraded"] is True
+    assert main_module.current_result is stored
+    assert stored.alignment_degraded is True
+
+
+def test_endpoint_returns_500_for_alignment_errors(client, monkeypatch, audio_file):
+    tc, main_module = client
+    monkeypatch.setattr(main_module, "current_result", _loaded_result(audio_file))
+    monkeypatch.setattr(
+        main_module.transcriber,
+        "realign_segments",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("alignment bug")),
+    )
+
+    resp = tc.post(
+        "/api/realign",
+        json={"segments": [{"start": 0.0, "end": 1.0, "text": "Labas"}]},
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"]["raw"] == "alignment bug"

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -135,22 +135,26 @@ export function App() {
       api.registerResync(null)
       return
     }
-    api.registerResync(() => ({
-      result: result
-        ? {
-            segments: result.segments,
-            language: result.language,
-            duration: result.duration,
-            audio_path: result.audioPath,
-          }
-        : undefined,
-      uiState: {
-        settings,
-        groups,
-        presets: builtinPresetNames(),
-        render: buildRenderBody(settings, groups, groupsEdited),
-      },
-    }))
+    api.registerResync(() => {
+      const liveResult = projectIORef.current?.gather().transcriptionResult ?? result
+      return {
+        result: liveResult
+          ? {
+              segments: liveResult.segments,
+              language: liveResult.language,
+              duration: liveResult.duration,
+              audio_path: liveResult.audioPath,
+              alignment_degraded: Boolean(liveResult.alignmentDegraded),
+            }
+          : undefined,
+        uiState: {
+          settings,
+          groups,
+          presets: builtinPresetNames(),
+          render: buildRenderBody(settings, groups, groupsEdited),
+        },
+      }
+    })
     return () => api.registerResync(null)
   }, [screen, result, settings, groups, groupsEdited])
 
@@ -203,6 +207,7 @@ export function App() {
           language: tr.language,
           duration: tr.duration,
           audio_path: tr.audioPath,
+          alignment_degraded: Boolean(tr.alignmentDegraded),
         })
         .catch(() => {})
     }

--- a/src/renderer/src/components/screens/AlignmentNotice.test.tsx
+++ b/src/renderer/src/components/screens/AlignmentNotice.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+import { AlignmentNotice } from './AlignmentNotice'
+
+describe('AlignmentNotice', () => {
+  test('renders a persistent status when timings are degraded', () => {
+    const html = renderToStaticMarkup(<AlignmentNotice visible />)
+
+    expect(html).toContain('role="status"')
+    expect(html).toContain('Approximate word timings')
+    expect(html).toContain('karaoke timing may be less precise')
+  })
+
+  test('renders nothing for forced-aligned results', () => {
+    expect(renderToStaticMarkup(<AlignmentNotice visible={false} />)).toBe('')
+  })
+})

--- a/src/renderer/src/components/screens/AlignmentNotice.tsx
+++ b/src/renderer/src/components/screens/AlignmentNotice.tsx
@@ -1,0 +1,24 @@
+interface AlignmentNoticeProps {
+  visible: boolean
+}
+
+/** Persistent warning shown whenever any word timings are approximate. */
+export function AlignmentNotice({ visible }: AlignmentNoticeProps) {
+  if (!visible) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="shrink-0 border-b px-3 py-2 text-xs"
+      style={{
+        color: 'var(--color-warning)',
+        borderColor: 'color-mix(in srgb, var(--color-warning) 35%, transparent)',
+        background: 'color-mix(in srgb, var(--color-warning) 10%, var(--color-surface))',
+      }}
+    >
+      <span className="font-medium">Approximate word timings.</span> Forced alignment was
+      unavailable, so timeline and karaoke timing may be less precise.
+    </div>
+  )
+}

--- a/src/renderer/src/components/screens/ResultsScreen.tsx
+++ b/src/renderer/src/components/screens/ResultsScreen.tsx
@@ -20,6 +20,7 @@ import { useUndoRedo } from '../../hooks/useUndoRedo'
 import { useToast } from '../../hooks/useToast'
 import { api, type RealignSegmentPayload } from '../../lib/api'
 import { AudioPlayer, type AudioPlayerHandle } from '../player/AudioPlayer'
+import { AlignmentNotice } from './AlignmentNotice'
 import { SubtitleEditor } from '../editor/SubtitleEditor'
 import { GroupEditor } from '../editor/GroupEditor'
 import type { WordStyleDefaults } from '../editor/WordStylePopup'
@@ -76,6 +77,9 @@ export function ResultsScreen({
   const [editorWidth, setEditorWidth] = useState(420)
   // Segment id currently being re-aligned via /api/realign (null = idle).
   const [realigningSegId, setRealigningSegId] = useState<string | null>(null)
+  // Once any fallback timings enter the transcript, keep the warning visible:
+  // later successful realignments do not prove every other word is precise.
+  const [alignmentDegraded, setAlignmentDegraded] = useState(Boolean(result.alignmentDegraded))
 
   const playerRef = useRef<AudioPlayerHandle>(null)
   const { toast } = useToast()
@@ -324,7 +328,7 @@ export function ResultsScreen({
           suggestedName: suggestProjectName(result.audioPath),
           selectedFilePath: result.audioPath,
           outputDir: 'output',
-          transcriptionResult: { ...result, segments },
+          transcriptionResult: { ...result, segments, alignmentDegraded },
           studioSettings: settings,
           customGroupsEdited: anyEdited,
           studioGroups: anyEdited || hasPosOverrides ? groups : null,
@@ -347,6 +351,7 @@ export function ResultsScreen({
         // the user can revert. setSegmentsEdited re-publishes derived groups.
         pushUndo()
         setSegments(agentResult.segments)
+        if (agentResult.alignmentDegraded) setAlignmentDegraded(true)
         setSegmentsEdited(true)
       },
       applyWordOverrides: (edits: WordOverrideEdit[]) => {
@@ -504,7 +509,12 @@ export function ResultsScreen({
           })
         )
         setSegmentsEdited(true)
-        toast('Word timings re-aligned', 'success')
+        if (res.alignment_degraded) {
+          setAlignmentDegraded(true)
+          toast('Using approximate word timings — forced alignment is unavailable', 'info')
+        } else {
+          toast('Word timings re-aligned', 'success')
+        }
       } catch (err) {
         const detail = err instanceof Error ? err.message : 'Unknown error'
         toast(`Re-align failed: ${detail}`, 'error')
@@ -661,6 +671,7 @@ export function ResultsScreen({
 
       {/* Right area: player */}
       <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+        <AlignmentNotice visible={alignmentDegraded} />
         <AudioPlayer
           ref={playerRef}
           audioPath={result.audioPath}

--- a/src/renderer/src/lib/api.test.ts
+++ b/src/renderer/src/lib/api.test.ts
@@ -454,5 +454,28 @@ describe('CapForgeAPI', () => {
       expect(result.duration).toBe(12.5)
       expect(result.language).toBe('en')
     })
+
+    test('preserves degraded alignment state for the persistent UI notice', () => {
+      const raw: TranscriptionResult = {
+        segments: [{ id: 'wire-segment', start: 0, end: 1, text: 'Labas', words: [] }],
+        language: 'lt',
+        duration: 1,
+        audio_path: 'audio.wav',
+        alignment_degraded: true,
+      }
+
+      expect(normalizeResult(raw).alignmentDegraded).toBe(true)
+    })
+
+    test('defaults older results without the flag to precise alignment', () => {
+      const raw: TranscriptionResult = {
+        segments: [{ id: 'wire-segment', start: 0, end: 1, text: 'Labas', words: [] }],
+        language: 'lt',
+        duration: 1,
+        audio_path: 'audio.wav',
+      }
+
+      expect(normalizeResult(raw).alignmentDegraded).toBe(false)
+    })
   })
 })

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -79,6 +79,7 @@ export interface TranscriptionResult {
   language: string
   duration: number
   audio_path: string
+  alignment_degraded?: boolean
 }
 
 export interface VideoInfo {
@@ -109,6 +110,7 @@ export function normalizeResult(raw: TranscriptionResult): AppTranscriptionResul
     language: raw.language,
     duration: raw.duration,
     audioPath: raw.audio_path,
+    alignmentDegraded: raw.alignment_degraded ?? false,
   }
 }
 
@@ -315,7 +317,10 @@ class CapForgeAPI {
 
   /** Re-run WhisperX forced alignment on edited segments (audio stays server-side). */
   realignSegments(segments: RealignSegmentPayload[], language?: string) {
-    return this.post<{ segments: RealignSegmentPayload[] }>('/api/realign', { segments, language })
+    return this.post<{ segments: RealignSegmentPayload[]; alignment_degraded: boolean }>(
+      '/api/realign',
+      { segments, language }
+    )
   }
 
   /** Mirror the renderer's UI state (settings + groups) so the agent can read it. */

--- a/src/renderer/src/types/app.ts
+++ b/src/renderer/src/types/app.ts
@@ -81,6 +81,8 @@ export interface TranscriptionResult {
   language: string
   duration: number
   audioPath: string
+  /** True when any word timings were approximated instead of force-aligned. */
+  alignmentDegraded?: boolean
 }
 
 /** Progress event pushed over WebSocket from the Python backend. */


### PR DESCRIPTION
## Summary

Fixes Lithuanian transcription failing with:

> No default align-model for language: lt

WhisperX does not include a default Lithuanian alignment model, so CapForge now supplies a compatible model explicitly.

## Changes

- Added a centralized language-to-alignment-model mapping.
- Configured `m3hrdadfi/wav2vec2-large-xlsr-lithuanian` for Lithuanian.
- Reused the same model-loading helper for initial transcription and edited-caption realignment.
- Preserved Whisper transcription segments when forced alignment is unavailable.
- Added evenly distributed approximate word timings as a graceful fallback.
- Added a clear warning whenever approximate timings are used.
- Added tests for Lithuanian, English defaults, loading failures, and realignment.

## Model and license

The Lithuanian model uses `Wav2Vec2ForCTC` and `Wav2Vec2Processor`, making it compatible with WhisperX’s custom `model_name` loader.

The model is licensed under Apache-2.0, which is compatible with CapForge’s MIT-licensed distribution. Model licensing and usage are documented in `THIRD_PARTY_MODELS.md`.

## Validation

- Focused alignment tests: `21 passed`
- Python byte-compilation: passed
- `git diff --check`: passed

The broader backend run produced `323 passed, 23 skipped`, with 11 unrelated environment-specific failures involving Windows process mocking, symlink privileges, and golden-image rendering.