### PR TITLE
Add searchable system font picker

### DIFF
--- a/backend/engine/system_fonts.py
+++ b/backend/engine/system_fonts.py
@@ -1,0 +1,189 @@
+"""Discover installed font families and resolve them to local font files.
+
+The UI and export pipeline share this index so the searchable picker only
+offers faces that Pillow can actually load. Results are cached for the process
+lifetime; scanning a typical system font directory takes a fraction of a second.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+from PIL import ImageFont
+
+
+FONT_EXTENSIONS = {".ttf", ".otf", ".ttc", ".otc", ".dfont"}
+COLLECTION_EXTENSIONS = {".ttc", ".otc", ".dfont"}
+BOLD_STYLE_TOKENS = ("bold", "black", "heavy", "semibold", "semi bold", "demi")
+ITALIC_STYLE_TOKENS = ("italic", "oblique")
+REGULAR_STYLE_TOKENS = ("regular", "normal", "roman", "book")
+
+
+@dataclass(frozen=True)
+class SystemFontFace:
+    """One loadable face in an installed font file or collection."""
+
+    family: str
+    style: str
+    path: str
+    index: int = 0
+
+    @property
+    def bold(self) -> bool:
+        style = self.style.casefold()
+        return any(token in style for token in BOLD_STYLE_TOKENS)
+
+    @property
+    def italic(self) -> bool:
+        style = self.style.casefold()
+        return any(token in style for token in ITALIC_STYLE_TOKENS)
+
+
+def _system_font_directories() -> tuple[Path, ...]:
+    if sys.platform == "win32":
+        windir = Path(os.environ.get("WINDIR", "C:/Windows"))
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        directories = [windir / "Fonts"]
+        if local_app_data:
+            directories.append(Path(local_app_data) / "Microsoft" / "Windows" / "Fonts")
+        return tuple(directories)
+    if sys.platform == "darwin":
+        return (
+            Path.home() / "Library" / "Fonts",
+            Path("/Library/Fonts"),
+            Path("/Network/Library/Fonts"),
+            Path("/System/Library/Fonts"),
+            Path("/System/Library/Fonts/Supplemental"),
+        )
+    return (
+        Path.home() / ".fonts",
+        Path.home() / ".local" / "share" / "fonts",
+        Path("/usr/local/share/fonts"),
+        Path("/usr/share/fonts"),
+    )
+
+
+def _windows_registry_font_paths() -> list[Path]:
+    """Return registered Windows font paths, including per-user installations."""
+
+    if sys.platform != "win32":
+        return []
+    try:
+        import winreg
+    except ImportError:
+        return []
+
+    windir_fonts = Path(os.environ.get("WINDIR", "C:/Windows")) / "Fonts"
+    user_fonts = Path(os.environ.get("LOCALAPPDATA", "")) / "Microsoft" / "Windows" / "Fonts"
+    registry_key = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts"
+    entries: list[Path] = []
+
+    for root, relative_base in (
+        (winreg.HKEY_LOCAL_MACHINE, windir_fonts),
+        (winreg.HKEY_CURRENT_USER, user_fonts),
+    ):
+        try:
+            with winreg.OpenKey(root, registry_key) as key:
+                value_count = winreg.QueryInfoKey(key)[1]
+                for index in range(value_count):
+                    _name, value, _kind = winreg.EnumValue(key, index)
+                    if not isinstance(value, str):
+                        continue
+                    expanded = Path(os.path.expandvars(value))
+                    entries.append(expanded if expanded.is_absolute() else relative_base / expanded)
+        except OSError:
+            continue
+    return entries
+
+
+def _system_font_paths() -> tuple[str, ...]:
+    paths: dict[str, str] = {}
+    candidates: list[Path] = _windows_registry_font_paths()
+    for directory in _system_font_directories():
+        if not directory.is_dir():
+            continue
+        try:
+            candidates.extend(path for path in directory.rglob("*") if path.is_file())
+        except OSError:
+            continue
+
+    for path in candidates:
+        if path.suffix.casefold() not in FONT_EXTENSIONS:
+            continue
+        try:
+            absolute = str(path.expanduser().resolve())
+        except OSError:
+            absolute = str(path.expanduser().absolute())
+        paths.setdefault(os.path.normcase(absolute), absolute)
+    return tuple(sorted(paths.values(), key=str.casefold))
+
+
+def _scan_font_paths(paths: Iterable[str]) -> tuple[SystemFontFace, ...]:
+    faces: list[SystemFontFace] = []
+    for path in paths:
+        max_faces = 64 if Path(path).suffix.casefold() in COLLECTION_EXTENSIONS else 1
+        for index in range(max_faces):
+            try:
+                font = ImageFont.truetype(path, 12, index=index)
+                family, style = font.getname()
+            except (OSError, ValueError):
+                break
+            family = str(family).strip()
+            if family:
+                faces.append(
+                    SystemFontFace(
+                        family=family,
+                        style=str(style or "Regular").strip(),
+                        path=path,
+                        index=index,
+                    )
+                )
+    return tuple(faces)
+
+
+@lru_cache(maxsize=1)
+def system_font_faces() -> tuple[SystemFontFace, ...]:
+    return _scan_font_paths(_system_font_paths())
+
+
+def list_system_font_families() -> list[str]:
+    """Return unique installed family names sorted for display."""
+
+    families: dict[str, str] = {}
+    for face in system_font_faces():
+        families.setdefault(face.family.casefold(), face.family)
+    return sorted(families.values(), key=str.casefold)
+
+
+def find_system_font_face(family: str, bold: bool = False) -> SystemFontFace | None:
+    """Resolve a family to its closest upright regular/bold installed face."""
+
+    normalized = family.strip().casefold()
+    if not normalized:
+        return None
+    matches = [face for face in system_font_faces() if face.family.casefold() == normalized]
+    if not matches:
+        return None
+
+    def score(face: SystemFontFace) -> tuple[int, int, int, str, int]:
+        style = face.style.casefold()
+        return (
+            0 if face.bold == bold else 1,
+            1 if face.italic else 0,
+            0 if any(token in style for token in REGULAR_STYLE_TOKENS) else 1,
+            face.path.casefold(),
+            face.index,
+        )
+
+    return min(matches, key=score)
+
+
+def clear_system_font_cache() -> None:
+    """Clear the process cache (primarily useful for tests or a future refresh UI)."""
+
+    system_font_faces.cache_clear()

--- a/backend/exporters/video_render.py
+++ b/backend/exporters/video_render.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
 
+from backend.engine.system_fonts import find_system_font_face
 from backend.models.schemas import (
     JobStatus,
     ProgressUpdate,
@@ -192,6 +193,19 @@ def _get_font(family: str, size: int, custom_path: str | None = None, bold: bool
     elif custom_path:
         logger.warning("Custom font path not found: %s", custom_path)
 
+    system_face = find_system_font_face(family, bold)
+    if system_face:
+        try:
+            logger.info(
+                "Loading system font: %s (face=%d, size=%d)",
+                system_face.path,
+                system_face.index,
+                size,
+            )
+            return ImageFont.truetype(system_face.path, size, index=system_face.index)
+        except Exception as e:
+            logger.warning("Failed to load system font %s: %s", system_face.path, e)
+
     for path in _find_font_candidates(family, bold):
         if os.path.isfile(path):
             try:
@@ -225,6 +239,9 @@ def resolve_font_file(
     """
     if custom_path and os.path.isfile(custom_path):
         return custom_path
+    system_face = find_system_font_face(family, bold)
+    if system_face:
+        return system_face.path
     for path in _find_font_candidates(family, bold):
         if os.path.isfile(path):
             return path

--- a/backend/main.py
+++ b/backend/main.py
@@ -39,6 +39,7 @@ from backend.agent_bridge import (
 from backend.engine.errors import explain
 from backend.engine.hardware import detect_hardware
 from backend.engine.moments import find_semantic_moments, find_transcript_moments
+from backend.engine.system_fonts import list_system_font_families
 from backend.engine.transcriber import Transcriber, TranscriptionCancelled
 from backend.exporters.ass_export import export_ass
 from backend.exporters.frame_qa import analyze_layout, render_qa_frame_png
@@ -390,6 +391,12 @@ async def get_models():
         "available": ["tiny", "base", "small", "medium", "large", "large-v2", "large-v3"],
         "recommended": hw.recommended_model.value,
     }
+
+
+@app.get("/api/fonts/system", dependencies=[Depends(require_local_token)])
+async def get_system_fonts():
+    """Return installed font families that the local renderer can resolve."""
+    return {"fonts": await asyncio.to_thread(list_system_font_families)}
 
 
 @app.get("/api/status")

--- a/backend/tests/test_local_auth.py
+++ b/backend/tests/test_local_auth.py
@@ -109,6 +109,23 @@ def test_serve_audio_accepts_agent_token(client, source_audio):
     assert res.status_code == 200
 
 
+# ── Auth: installed font catalog ────────────────────────────────────────────
+
+def test_system_fonts_without_token_is_401(client):
+    res = client.get("/api/fonts/system")
+    assert res.status_code == 401
+
+
+def test_system_fonts_with_valid_token_is_200(client, main_module, monkeypatch):
+    monkeypatch.setattr(main_module, "list_system_font_families", lambda: ["Arial", "Inter"])
+    res = client.get(
+        "/api/fonts/system",
+        headers={"X-CapForge-Local-Token": "test-local-token-abc"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"fonts": ["Arial", "Inter"]}
+
+
 # ── Path allowlist: serve-audio ──────────────────────────────────────────────
 
 def test_serve_audio_rejects_path_outside_allowlist(client, tmp_path):

--- a/backend/tests/test_system_fonts.py
+++ b/backend/tests/test_system_fonts.py
@@ -1,0 +1,66 @@
+from backend.engine import system_fonts
+
+
+class FakeFont:
+    def __init__(self, family: str, style: str):
+        self._name = (family, style)
+
+    def getname(self):
+        return self._name
+
+
+def test_scan_font_paths_reads_collection_faces(monkeypatch):
+    names = {
+        ("regular.ttf", 0): ("Example Sans", "Regular"),
+        ("family.ttc", 0): ("Collection Sans", "Regular"),
+        ("family.ttc", 1): ("Collection Serif", "Bold"),
+    }
+
+    def fake_truetype(path, _size, index=0):
+        try:
+            family, style = names[(path, index)]
+        except KeyError as exc:
+            raise OSError("no more faces") from exc
+        return FakeFont(family, style)
+
+    monkeypatch.setattr(system_fonts.ImageFont, "truetype", fake_truetype)
+
+    faces = system_fonts._scan_font_paths(["regular.ttf", "family.ttc"])
+
+    assert [(face.family, face.index) for face in faces] == [
+        ("Example Sans", 0),
+        ("Collection Sans", 0),
+        ("Collection Serif", 1),
+    ]
+
+
+def test_family_list_is_unique_and_sorted(monkeypatch):
+    faces = (
+        system_fonts.SystemFontFace("Zulu", "Regular", "/z.ttf"),
+        system_fonts.SystemFontFace("alpha", "Regular", "/a.ttf"),
+        system_fonts.SystemFontFace("Alpha", "Bold", "/ab.ttf"),
+    )
+    monkeypatch.setattr(system_fonts, "system_font_faces", lambda: faces)
+
+    assert system_fonts.list_system_font_families() == ["alpha", "Zulu"]
+
+
+def test_resolver_prefers_requested_weight_and_upright_face(monkeypatch):
+    faces = (
+        system_fonts.SystemFontFace("Example", "Regular", "/regular.ttf"),
+        system_fonts.SystemFontFace("Example", "Bold Italic", "/bold-italic.ttf"),
+        system_fonts.SystemFontFace("Example", "Bold", "/bold.ttf", index=2),
+    )
+    monkeypatch.setattr(system_fonts, "system_font_faces", lambda: faces)
+
+    regular = system_fonts.find_system_font_face("example", bold=False)
+    bold = system_fonts.find_system_font_face("Example", bold=True)
+
+    assert regular is not None and regular.path == "/regular.ttf"
+    assert bold is not None and bold.path == "/bold.ttf" and bold.index == 2
+
+
+def test_resolver_returns_none_for_unknown_family(monkeypatch):
+    monkeypatch.setattr(system_fonts, "system_font_faces", lambda: ())
+
+    assert system_fonts.find_system_font_face("Missing") is None

--- a/docs/plans/shareable-presets-export-import.md
+++ b/docs/plans/shareable-presets-export-import.md
@@ -117,7 +117,7 @@ plus a pure, testable helper module.
 ### 1a. New file `electron/preset-io.js` (pure functions, CommonJS, no Electron imports)
 Export:
 - Constants above.
-- `classifyFont({ customFontPath, bundledFontsDir, fs, path })` → `'none' | 'bundled' | 'custom' | 'missing'`.
+- `classifyFont({ fontFamily, customFontPath, bundledFontsDir, fs, path })` → `'none' | 'system' | 'bundled' | 'custom' | 'missing'`.
   - `none` if `customFontPath` falsy.
   - `bundled` if `fs.existsSync(path.join(bundledFontsDir, path.basename(customFontPath)))`.
   - `custom` if the file at `customFontPath` is readable.

--- a/electron/main.js
+++ b/electron/main.js
@@ -635,6 +635,7 @@ app.whenReady().then(async () => {
 
     // Classify the preset's custom font and build the embedded `font` block.
     const kind = presetIO.classifyFont({
+      fontFamily: preset.font,
       customFontPath: preset.customFontPath,
       bundledFontsDir,
       fs,
@@ -642,7 +643,12 @@ app.whenReady().then(async () => {
     })
     let font = null
     let fontStatus = 'none'
-    if (kind === 'bundled') {
+    if (kind === 'system') {
+      // System font files are not embedded: their redistribution licenses are
+      // unknown. The renderer confirms this portability limitation with the
+      // user before export and reports it again after the file is written.
+      fontStatus = 'system'
+    } else if (kind === 'bundled') {
       font = {
         family: preset.font,
         fileName: path.basename(preset.customFontPath),

--- a/electron/preset-io.js
+++ b/electron/preset-io.js
@@ -17,7 +17,10 @@ const MAX_FONT_BYTES = 10 * 1024 * 1024
 
 /**
  * Classify how a preset's custom font should travel in an export.
- *  - 'none'    : the preset has no custom font path.
+ *  - 'none'    : the preset has no font family or custom font path.
+ *  - 'system'  : the preset references an installed font by family only. The
+ *                file is not embedded because its redistribution rights are
+ *                unknown, so the renderer must warn before export.
  *  - 'bundled' : the font basename matches a file in the local bundled Fonts dir
  *                — referenced by name only, re-resolved on the target machine.
  *  - 'custom'  : the file at customFontPath is readable — its bytes get embedded.
@@ -28,8 +31,8 @@ const MAX_FONT_BYTES = 10 * 1024 * 1024
  * locally without embedding bytes; the on-disk basename collision means the
  * bundled file is what every machine will resolve to anyway.
  */
-function classifyFont({ customFontPath, bundledFontsDir, fs, path }) {
-  if (!customFontPath) return 'none'
+function classifyFont({ fontFamily, customFontPath, bundledFontsDir, fs, path }) {
+  if (!customFontPath) return fontFamily ? 'system' : 'none'
   const base = path.basename(customFontPath)
   // Bundled basename takes priority — re-resolved locally, no embedding needed.
   if (fs.existsSync(path.join(bundledFontsDir, base))) return 'bundled'

--- a/electron/preset-io.test.js
+++ b/electron/preset-io.test.js
@@ -402,7 +402,7 @@ test('buildPresetExport embeds a user font as base64 (custom classification)', (
 test('buildPresetExport references a bundled CapForge font by name only (no embedded bytes)', () => {
   const fs = {
     existsSync(p) {
-      return p === '/app/Fonts/Inter-Bold.ttf'
+      return p.replaceAll('\\', '/') === '/app/Fonts/Inter-Bold.ttf'
     },
   }
   const kind = classifyFont({
@@ -437,10 +437,24 @@ test('classifyFont returns "none" when there is no custom font path', () => {
   )
 })
 
+test('classifyFont identifies a system font referenced only by family', () => {
+  const fs = { existsSync: () => false }
+  assert.equal(
+    classifyFont({
+      fontFamily: 'Arial',
+      customFontPath: '',
+      bundledFontsDir: '/app/Fonts',
+      fs,
+      path,
+    }),
+    'system'
+  )
+})
+
 test('classifyFont returns "bundled" for a font path (bundled basename takes priority)', () => {
   const fs = {
     existsSync(p) {
-      return p === '/app/Fonts/Inter-Bold.ttf'
+      return p.replaceAll('\\', '/') === '/app/Fonts/Inter-Bold.ttf'
     },
   }
   const kind = classifyFont({

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,7 +15,7 @@ export interface PresetSettings {
 }
 
 export type ExportPresetResult =
-  | { filePath: string; fontStatus: 'embedded' | 'bundled' | 'missing' | 'none' }
+  | { filePath: string; fontStatus: 'embedded' | 'bundled' | 'missing' | 'system' | 'none' }
   | { error: string }
 
 export type ImportPresetResult =

--- a/src/renderer/src/components/editor/WordStylePopup.tsx
+++ b/src/renderer/src/components/editor/WordStylePopup.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { WordOverrides, WordTransition } from '../../types/app'
 import { loadAllFonts, registerFontFromBuffer, type FontInfo } from '../../lib/fonts'
+import { FontCombobox } from '../ui/FontCombobox'
 
 // ── Props ───────────────────────────────────────────────────────
 
@@ -275,11 +276,13 @@ export function WordStylePopup({
       } catch {
         /* best-effort */
       }
-      setFonts((prev) =>
-        prev.some((f) => f.name === name)
-          ? prev
-          : [{ name, path: savedPath, bundled: false }, ...prev]
-      )
+      setFonts((prev) => {
+        const normalized = name.toLocaleLowerCase()
+        return [
+          { name, path: savedPath, source: 'custom' },
+          ...prev.filter((font) => font.name.toLocaleLowerCase() !== normalized),
+        ]
+      })
       setFontFamily(name)
       setFontPath(savedPath)
     } catch {
@@ -333,27 +336,17 @@ export function WordStylePopup({
           <label className="w-20 shrink-0" style={{ color: 'var(--color-text-2)' }}>
             Font
           </label>
-          <select
+          <FontCombobox
+            fonts={fonts}
             value={fontFamily}
-            onChange={(e) => {
-              const name = e.target.value
-              setFontFamily(name)
-              setFontPath(fonts.find((f) => f.name === name)?.path ?? '')
+            emptyLabel="— Global —"
+            onChange={(font) => {
+              setFontFamily(font?.name ?? '')
+              setFontPath(font?.path ?? '')
             }}
-            className="flex-1 min-w-0 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs"
-            style={fontFamily ? { fontFamily: `"${fontFamily}", sans-serif` } : undefined}
-          >
-            <option value="">— Global —</option>
-            {fonts.map((f) => (
-              <option
-                key={`${f.name}|${f.path}`}
-                value={f.name}
-                style={{ fontFamily: `"${f.name}", sans-serif` }}
-              >
-                {f.bundled ? f.name : `${f.name} ★`}
-              </option>
-            ))}
-          </select>
+            className="flex-1"
+            ariaLabel="Word font family"
+          />
           <button
             type="button"
             onClick={() => fileRef.current?.click()}

--- a/src/renderer/src/components/studio/PresetPicker.tsx
+++ b/src/renderer/src/components/studio/PresetPicker.tsx
@@ -11,6 +11,7 @@ import type { StudioSettings } from './StudioPanel'
 import {
   BUILTIN_PRESETS,
   applyPreset,
+  getSystemFontExportWarning,
   studioToVanilla,
   type BuiltinPreset,
   type VanillaPreset,
@@ -162,6 +163,8 @@ export function PresetPicker({ settings, onChange }: PresetPickerProps) {
       toast('Export unavailable — please restart CapForge', 'error')
       return
     }
+    const systemFontWarning = getSystemFontExportWarning(p.settings)
+    if (systemFontWarning && !window.confirm(systemFontWarning)) return
     try {
       const res = await window.subforge.exportPreset(p.name)
       if (!res) {
@@ -175,8 +178,13 @@ export function PresetPicker({ settings, onChange }: PresetPickerProps) {
       const msg =
         res.fontStatus === 'missing'
           ? `Exported "${p.name}" — its custom font wasn't included (missing or too large)`
-          : `Exported to ${res.filePath}`
-      toast(msg, res.fontStatus === 'missing' ? 'info' : 'success')
+          : res.fontStatus === 'system'
+            ? `Exported "${p.name}" — system font "${p.settings.font}" is not included`
+            : `Exported to ${res.filePath}`
+      toast(
+        msg,
+        res.fontStatus === 'missing' || res.fontStatus === 'system' ? 'info' : 'success'
+      )
     } catch {
       toast('Export failed', 'error')
     }

--- a/src/renderer/src/components/ui/FontCombobox.test.tsx
+++ b/src/renderer/src/components/ui/FontCombobox.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test, vi } from 'vitest'
+import type { FontInfo } from '../../lib/fonts'
+import { filterFonts, FontCombobox } from './FontCombobox'
+
+const FONTS: FontInfo[] = [
+  { name: 'Arial', path: '', source: 'system' },
+  { name: 'Caviar Dreams', path: '/bundle/caviar.ttf', source: 'bundled' },
+  { name: 'My Brand', path: '/user/brand.otf', source: 'custom' },
+]
+
+describe('FontCombobox', () => {
+  test('renders an editable, accessible collapsed font field', () => {
+    const html = renderToStaticMarkup(
+      <FontCombobox fonts={FONTS} value="Arial" emptyLabel="System default" onChange={vi.fn()} />
+    )
+
+    expect(html).toContain('role="combobox"')
+    expect(html).toContain('aria-label="Font"')
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toContain('value="Arial"')
+  })
+
+  test('filters case-insensitively by family and source label', () => {
+    expect(filterFonts(FONTS, 'caviar').map((font) => font.name)).toEqual(['Caviar Dreams'])
+    expect(filterFonts(FONTS, 'CUSTOM').map((font) => font.name)).toEqual(['My Brand'])
+    expect(filterFonts(FONTS, 'installed').map((font) => font.name)).toEqual(['Arial'])
+  })
+})

--- a/src/renderer/src/components/ui/FontCombobox.test.tsx
+++ b/src/renderer/src/components/ui/FontCombobox.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, test, vi } from 'vitest'
 import type { FontInfo } from '../../lib/fonts'
-import { filterFonts, FontCombobox } from './FontCombobox'
+import { filterFonts, FontCombobox, resolveFontSelection } from './FontCombobox'
 
 const FONTS: FontInfo[] = [
   { name: 'Arial', path: '', source: 'system' },
@@ -25,5 +25,15 @@ describe('FontCombobox', () => {
     expect(filterFonts(FONTS, 'caviar').map((font) => font.name)).toEqual(['Caviar Dreams'])
     expect(filterFonts(FONTS, 'CUSTOM').map((font) => font.name)).toEqual(['My Brand'])
     expect(filterFonts(FONTS, 'installed').map((font) => font.name)).toEqual(['Arial'])
+  })
+
+  test('resolves the complete original selection for Escape rollback', () => {
+    expect(resolveFontSelection(FONTS, 'My Brand')).toEqual({
+      name: 'My Brand',
+      path: '/user/brand.otf',
+      source: 'custom',
+    })
+    expect(resolveFontSelection(FONTS, '')).toBeNull()
+    expect(resolveFontSelection(FONTS, 'Missing Font')).toBeNull()
   })
 })

--- a/src/renderer/src/components/ui/FontCombobox.tsx
+++ b/src/renderer/src/components/ui/FontCombobox.tsx
@@ -1,0 +1,330 @@
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react'
+import { createPortal } from 'react-dom'
+import type { FontInfo, FontSource } from '../../lib/fonts'
+
+interface FontComboboxProps {
+  fonts: FontInfo[]
+  value: string
+  emptyLabel: string
+  onChange: (font: FontInfo | null) => void
+  disabled?: boolean
+  ariaLabel?: string
+  className?: string
+}
+
+const SOURCE_LABELS: Record<FontSource, string> = {
+  system: 'Installed',
+  bundled: 'CapForge',
+  custom: 'Custom',
+}
+
+export function filterFonts(fonts: FontInfo[], query: string): FontInfo[] {
+  const needle = query.trim().toLocaleLowerCase()
+  if (!needle) return fonts
+  return fonts.filter((font) => {
+    const source = SOURCE_LABELS[font.source].toLocaleLowerCase()
+    return font.name.toLocaleLowerCase().includes(needle) || source.includes(needle)
+  })
+}
+
+export function FontCombobox({
+  fonts,
+  value,
+  emptyLabel,
+  onChange,
+  disabled = false,
+  ariaLabel = 'Font',
+  className = '',
+}: FontComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [popupStyle, setPopupStyle] = useState<CSSProperties>({})
+  const rootRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const popupRef = useRef<HTMLDivElement>(null)
+  const listboxId = useId()
+  const optionIdBase = useId()
+
+  const selected = fonts.find((font) => font.name === value)
+  const filtered = useMemo(
+    () => (searching ? filterFonts(fonts, query) : fonts),
+    [fonts, query, searching]
+  )
+  const showEmptyOption =
+    !searching ||
+    !query.trim() ||
+    emptyLabel.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase())
+  const optionOffset = showEmptyOption ? 1 : 0
+  const optionCount = filtered.length + optionOffset
+  const activeOptionIndex = Math.min(activeIndex, Math.max(0, optionCount - 1))
+  const displayValue = open ? query : value || emptyLabel
+
+  function updatePopupPosition() {
+    const input = inputRef.current
+    if (!input) return
+    const rect = input.getBoundingClientRect()
+    const width = Math.max(240, rect.width)
+    const maxHeight = Math.min(300, window.innerHeight - 24)
+    const spaceBelow = window.innerHeight - rect.bottom - 8
+    const top =
+      spaceBelow >= Math.min(maxHeight, 220)
+        ? rect.bottom + 4
+        : Math.max(8, rect.top - maxHeight - 4)
+    const left = Math.min(Math.max(8, rect.left), Math.max(8, window.innerWidth - width - 8))
+    setPopupStyle({ position: 'fixed', top, left, width, maxHeight, zIndex: 'var(--z-dropdown)' })
+  }
+
+  function openPicker() {
+    if (disabled || open) return
+    setOpen(true)
+    setQuery(value)
+    setSearching(false)
+    const selectedIndex = fonts.findIndex((font) => font.name === value)
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex + 1 : 0)
+  }
+
+  function closePicker() {
+    setOpen(false)
+    setQuery('')
+    setSearching(false)
+    setActiveIndex(0)
+  }
+
+  function selectFont(font: FontInfo | null) {
+    onChange(font)
+    closePicker()
+    requestAnimationFrame(() => inputRef.current?.blur())
+  }
+
+  function previewOption(index: number) {
+    if (index < 0 || index >= optionCount) return
+    const font = showEmptyOption && index === 0 ? null : filtered[index - optionOffset]
+    if (font === undefined) return
+    setActiveIndex(index)
+    if (!searching) setQuery(font?.name ?? '')
+    onChange(font)
+  }
+
+  useLayoutEffect(() => {
+    if (!open) return
+    updatePopupPosition()
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function handleOutsidePointer(event: MouseEvent) {
+      const target = event.target as Node
+      if (!rootRef.current?.contains(target) && !popupRef.current?.contains(target)) closePicker()
+    }
+    function handleViewportChange() {
+      updatePopupPosition()
+    }
+    document.addEventListener('mousedown', handleOutsidePointer)
+    window.addEventListener('resize', handleViewportChange)
+    window.addEventListener('scroll', handleViewportChange, true)
+    return () => {
+      document.removeEventListener('mousedown', handleOutsidePointer)
+      window.removeEventListener('resize', handleViewportChange)
+      window.removeEventListener('scroll', handleViewportChange, true)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    document
+      .getElementById(`${optionIdBase}-${activeOptionIndex}`)
+      ?.scrollIntoView({ block: 'nearest' })
+  }, [activeOptionIndex, open, optionIdBase])
+
+  return (
+    <div ref={rootRef} className={`relative min-w-0 ${className}`}>
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-label={ariaLabel}
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && optionCount > 0 ? `${optionIdBase}-${activeOptionIndex}` : undefined
+        }
+        autoComplete="off"
+        value={displayValue}
+        disabled={disabled}
+        onFocus={openPicker}
+        onClick={openPicker}
+        onChange={(event) => {
+          if (!open) openPicker()
+          setQuery(event.target.value)
+          setSearching(true)
+          setActiveIndex(0)
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown') {
+            event.preventDefault()
+            if (!open) openPicker()
+            else if (optionCount > 0) {
+              previewOption(Math.min(optionCount - 1, activeOptionIndex + 1))
+            }
+          } else if (event.key === 'ArrowUp') {
+            event.preventDefault()
+            if (!open) openPicker()
+            else if (optionCount > 0) {
+              previewOption(Math.max(0, activeOptionIndex - 1))
+            }
+          } else if (event.key === 'Enter' && open) {
+            event.preventDefault()
+            if (optionCount > 0) {
+              selectFont(
+                showEmptyOption && activeOptionIndex === 0
+                  ? null
+                  : filtered[activeOptionIndex - optionOffset]
+              )
+            }
+          } else if (event.key === 'Escape' && open) {
+            event.preventDefault()
+            event.stopPropagation()
+            closePicker()
+            inputRef.current?.blur()
+          }
+        }}
+        className="field-input w-full pr-7 text-xs"
+        style={!open && selected ? { fontFamily: `"${selected.name}", sans-serif` } : undefined}
+      />
+      <svg
+        width="10"
+        height="6"
+        viewBox="0 0 10 6"
+        fill="none"
+        aria-hidden="true"
+        className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+      >
+        <path
+          d="M1 1l4 4 4-4"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ color: 'var(--color-text-3)' }}
+        />
+      </svg>
+
+      {open &&
+        createPortal(
+          <div
+            ref={popupRef}
+            style={popupStyle}
+            className="pop-in flex flex-col overflow-hidden rounded-md border border-[var(--color-border-2)] bg-[var(--color-surface-2)] shadow-2xl"
+          >
+            <div className="flex items-center justify-between border-b border-[var(--color-border)] px-2.5 py-1.5">
+              <span className="text-2xs" style={{ color: 'var(--color-text-3)' }}>
+                {query ? `${filtered.length} matches` : `${fonts.length} fonts`}
+              </span>
+              <span className="text-2xs" style={{ color: 'var(--color-text-3)' }}>
+                Type to search
+              </span>
+            </div>
+            <div id={listboxId} role="listbox" className="min-h-0 overflow-y-auto py-1">
+              {showEmptyOption && (
+                <FontOption
+                  id={`${optionIdBase}-0`}
+                  label={emptyLabel}
+                  sourceLabel="Default"
+                  selected={!value}
+                  active={activeOptionIndex === 0}
+                  onSelect={() => selectFont(null)}
+                />
+              )}
+              {filtered.map((font, index) => (
+                <FontOption
+                  key={`${font.source}|${font.name}|${font.path}`}
+                  id={`${optionIdBase}-${index + optionOffset}`}
+                  label={font.name}
+                  sourceLabel={SOURCE_LABELS[font.source]}
+                  selected={font.name === value}
+                  active={activeOptionIndex === index + optionOffset}
+                  fontFamily={font.name}
+                  onPointerMove={() => setActiveIndex(index + optionOffset)}
+                  onSelect={() => selectFont(font)}
+                />
+              ))}
+              {filtered.length === 0 && (
+                <div
+                  className="px-3 py-4 text-center text-xs"
+                  style={{ color: 'var(--color-text-3)' }}
+                >
+                  No fonts match “{query}”.
+                </div>
+              )}
+            </div>
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}
+
+interface FontOptionProps {
+  id: string
+  label: string
+  sourceLabel: string
+  selected: boolean
+  active: boolean
+  fontFamily?: string
+  onPointerMove?: () => void
+  onSelect: () => void
+}
+
+function FontOption({
+  id,
+  label,
+  sourceLabel,
+  selected,
+  active,
+  fontFamily,
+  onPointerMove,
+  onSelect,
+}: FontOptionProps) {
+  return (
+    <button
+      id={id}
+      type="button"
+      role="option"
+      aria-selected={selected}
+      onMouseDown={(event) => event.preventDefault()}
+      onPointerMove={onPointerMove}
+      onClick={onSelect}
+      className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs"
+      style={{
+        background: active ? 'var(--color-surface-3)' : 'transparent',
+        color: 'var(--color-text)',
+      }}
+    >
+      <span className="w-3 shrink-0 text-center" style={{ color: 'var(--color-accent)' }}>
+        {selected ? '✓' : ''}
+      </span>
+      <span
+        className="min-w-0 flex-1 truncate"
+        style={fontFamily ? { fontFamily: `"${fontFamily}", sans-serif` } : undefined}
+      >
+        {label}
+      </span>
+      <span className="shrink-0 text-2xs" style={{ color: 'var(--color-text-3)' }}>
+        {sourceLabel}
+      </span>
+    </button>
+  )
+}

--- a/src/renderer/src/components/ui/FontCombobox.tsx
+++ b/src/renderer/src/components/ui/FontCombobox.tsx
@@ -35,6 +35,10 @@ export function filterFonts(fonts: FontInfo[], query: string): FontInfo[] {
   })
 }
 
+export function resolveFontSelection(fonts: FontInfo[], value: string): FontInfo | null {
+  return fonts.find((font) => font.name === value) ?? null
+}
+
 export function FontCombobox({
   fonts,
   value,
@@ -52,10 +56,11 @@ export function FontCombobox({
   const rootRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const popupRef = useRef<HTMLDivElement>(null)
+  const openingSelectionRef = useRef<FontInfo | null>(null)
   const listboxId = useId()
   const optionIdBase = useId()
 
-  const selected = fonts.find((font) => font.name === value)
+  const selected = resolveFontSelection(fonts, value)
   const filtered = useMemo(
     () => (searching ? filterFonts(fonts, query) : fonts),
     [fonts, query, searching]
@@ -86,6 +91,7 @@ export function FontCombobox({
 
   function openPicker() {
     if (disabled || open) return
+    openingSelectionRef.current = resolveFontSelection(fonts, value)
     setOpen(true)
     setQuery(value)
     setSearching(false)
@@ -104,6 +110,15 @@ export function FontCombobox({
     onChange(font)
     closePicker()
     requestAnimationFrame(() => inputRef.current?.blur())
+  }
+
+  function cancelPicker() {
+    // Arrow-key navigation previews through onChange. Escape is a cancellation,
+    // so restore the complete original entry (including path/source), not just
+    // the family name.
+    onChange(openingSelectionRef.current)
+    closePicker()
+    inputRef.current?.blur()
   }
 
   function previewOption(index: number) {
@@ -197,8 +212,7 @@ export function FontCombobox({
           } else if (event.key === 'Escape' && open) {
             event.preventDefault()
             event.stopPropagation()
-            closePicker()
-            inputRef.current?.blur()
+            cancelPicker()
           }
         }}
         className="field-input w-full pr-7 text-xs"

--- a/src/renderer/src/components/ui/FontPicker.tsx
+++ b/src/renderer/src/components/ui/FontPicker.tsx
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { loadAllFonts, registerFontFromBuffer, type FontInfo } from '../../lib/fonts'
+import { FontCombobox } from './FontCombobox'
 
 interface FontPickerProps {
   value: string
@@ -52,8 +53,11 @@ export function FontPicker({ value, onChange }: FontPickerProps) {
         // Save failed — font still works for this session.
       }
       setFonts((prev) => {
-        if (prev.some((f) => f.name === name)) return prev
-        return [{ name, path: savedPath, bundled: false }, ...prev]
+        const normalized = name.toLocaleLowerCase()
+        return [
+          { name, path: savedPath, source: 'custom' },
+          ...prev.filter((font) => font.name.toLocaleLowerCase() !== normalized),
+        ]
       })
       onChange(name, savedPath)
     } finally {
@@ -82,39 +86,22 @@ export function FontPicker({ value, onChange }: FontPickerProps) {
     }
   }
 
-  function handleSelectChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const opt = fonts.find((f) => f.name === e.target.value)
-    if (opt) onChange(opt.name, opt.path)
-    else onChange('', '')
-  }
-
-  const selectedIsCustom = fonts.find((f) => f.name === value)?.bundled === false
+  const selectedIsCustom = fonts.find((f) => f.name === value)?.source === 'custom'
 
   return (
     <div className="flex items-center gap-1.5 min-w-0">
       <span className="w-[72px] shrink-0 text-xs" style={{ color: 'var(--color-text-2)' }}>
         Font
       </span>
-      <select
-        className="field-input flex-1 min-w-0 text-xs"
+      <FontCombobox
+        className="flex-1"
+        fonts={fonts}
         value={value}
-        onChange={handleSelectChange}
+        emptyLabel={loading ? 'Loading…' : 'System default'}
+        onChange={(font) => onChange(font?.name ?? '', font?.path ?? '')}
         disabled={loading || busy}
-        // Preview the currently selected font in the collapsed <select>
-        style={value ? { fontFamily: `"${value}", sans-serif` } : undefined}
-      >
-        {loading && <option>Loading…</option>}
-        {!loading && <option value="">System default</option>}
-        {fonts.map((f) => (
-          <option
-            key={`${f.name}|${f.path}`}
-            value={f.name}
-            style={{ fontFamily: `"${f.name}", sans-serif` }}
-          >
-            {f.bundled ? f.name : `${f.name} ★`}
-          </option>
-        ))}
-      </select>
+        ariaLabel="Font family"
+      />
 
       {/* Delete (only for user-added fonts, only when one is selected) */}
       {selectedIsCustom && (

--- a/src/renderer/src/lib/api.test.ts
+++ b/src/renderer/src/lib/api.test.ts
@@ -125,6 +125,22 @@ describe('CapForgeAPI', () => {
       expect(fetchMock.mock.calls[0][1]).toBeUndefined()
     })
 
+    test('getSystemFonts scopes the local token header to its gated route', async () => {
+      vi.stubGlobal('window', {
+        subforge: {
+          getBackendPort: vi.fn().mockResolvedValue(52690),
+          getLocalToken: vi.fn().mockResolvedValue('launch-token'),
+        },
+      })
+      fetchMock.mockResolvedValue(jsonResponse({ fonts: ['Arial', 'Verdana'] }))
+
+      await expect(api.getSystemFonts()).resolves.toEqual(['Arial', 'Verdana'])
+
+      expect(fetchMock).toHaveBeenCalledWith('http://127.0.0.1:52690/api/fonts/system', {
+        headers: { 'X-CapForge-Local-Token': 'launch-token' },
+      })
+    })
+
     test('propagates the local token as an encoded query param on getVideoInfo', async () => {
       fetchMock.mockResolvedValue(jsonResponse({ width: null, height: null, fps: null }))
       api.setLocalToken('tok en')

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -194,6 +194,15 @@ class CapForgeAPI {
     return res.json() as Promise<T>
   }
 
+  /** GET a specifically auth-gated local route without changing generic GET semantics. */
+  private async getWithLocalToken<T>(path: string): Promise<T> {
+    const headers: Record<string, string> = {}
+    if (this.localToken) headers['X-CapForge-Local-Token'] = this.localToken
+    const res = await fetch(`${this.base}${path}`, { headers })
+    if (!res.ok) throw await this.handleError(res)
+    return res.json() as Promise<T>
+  }
+
   private async post<T>(path: string, body: unknown): Promise<T> {
     // A subset of POST routes (e.g. /api/export, /api/render-video,
     // /api/export-hyperframes) are auth-gated because they write to a
@@ -250,6 +259,21 @@ class CapForgeAPI {
   }
   getModels() {
     return this.get<string[]>('/api/models')
+  }
+  async getSystemFonts(): Promise<string[]> {
+    // Font pickers can mount before SettingsPanel/useTranscription initialize
+    // the API client (for example when opening an existing project). Resolve
+    // the current backend connection here so this authenticated request does
+    // not race renderer startup.
+    const [port, token] = await Promise.all([
+      window.subforge.getBackendPort(),
+      window.subforge.getLocalToken(),
+    ])
+    this.setPort(port)
+    this.setLocalToken(token)
+    return this.getWithLocalToken<{ fonts: string[] }>('/api/fonts/system').then(
+      (response) => response.fonts ?? []
+    )
   }
   getStatus() {
     return this.get('/api/status')

--- a/src/renderer/src/lib/fonts.test.ts
+++ b/src/renderer/src/lib/fonts.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+import { mergeFontCatalogs } from './fonts'
+
+describe('mergeFontCatalogs', () => {
+  test('merges and alphabetizes installed, bundled, and custom fonts', () => {
+    const fonts = mergeFontCatalogs(
+      ['Verdana', 'Arial'],
+      [{ name: 'Caviar Dreams', path: '/bundle/caviar.ttf' }],
+      [{ name: 'Brand Font', path: '/user/brand.otf' }]
+    )
+
+    expect(fonts.map((font) => `${font.name}:${font.source}`)).toEqual([
+      'Arial:system',
+      'Brand Font:custom',
+      'Caviar Dreams:bundled',
+      'Verdana:system',
+    ])
+  })
+
+  test('prefers custom and bundled files over duplicate system family names', () => {
+    const fonts = mergeFontCatalogs(
+      ['Inter', 'Arial'],
+      [{ name: 'Inter', path: '/bundle/inter.ttf' }],
+      [{ name: 'ARIAL', path: '/user/arial.ttf' }]
+    )
+
+    expect(fonts).toEqual([
+      { name: 'ARIAL', path: '/user/arial.ttf', source: 'custom' },
+      { name: 'Inter', path: '/bundle/inter.ttf', source: 'bundled' },
+    ])
+  })
+
+  test('ignores blank installed-family names', () => {
+    expect(mergeFontCatalogs(['', '   '], [], [])).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/fonts.ts
+++ b/src/renderer/src/lib/fonts.ts
@@ -7,10 +7,14 @@
  * regardless of how many times <FontPicker> mounts.
  */
 
+import { api } from './api'
+
+export type FontSource = 'system' | 'bundled' | 'custom'
+
 export interface FontInfo {
-  name:     string
-  path:     string
-  bundled?: boolean
+  name: string
+  path: string
+  source: FontSource
 }
 
 // Track which (name|path) we've already registered so re-mounts are no-ops.
@@ -59,21 +63,49 @@ export async function registerFontFromBuffer(name: string, data: ArrayBuffer): P
 }
 
 /**
- * Load bundled fonts + user fonts, register them all, and return the combined
- * list. Used on <FontPicker> mount. Order: bundled first, then user fonts.
+ * Merge font sources by family name. A user font wins over a bundled face,
+ * which wins over the name-only system entry, so selecting a duplicate always
+ * uses the most explicit local file.
+ */
+export function mergeFontCatalogs(
+  systemNames: string[],
+  bundled: Array<{ name: string; path: string }>,
+  custom: Array<{ name: string; path: string }>
+): FontInfo[] {
+  const byName = new Map<string, FontInfo>()
+  for (const name of systemNames) {
+    const trimmed = name.trim()
+    if (trimmed)
+      byName.set(trimmed.toLocaleLowerCase(), { name: trimmed, path: '', source: 'system' })
+  }
+  for (const font of bundled) {
+    byName.set(font.name.toLocaleLowerCase(), { ...font, source: 'bundled' })
+  }
+  for (const font of custom) {
+    byName.set(font.name.toLocaleLowerCase(), { ...font, source: 'custom' })
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Load installed, bundled, and user fonts. Only bundled/user files need
+ * FontFace registration; Chromium already knows how to render system fonts.
  */
 export async function loadAllFonts(): Promise<FontInfo[]> {
-  const [bundled, custom] = await Promise.all([
+  const [system, bundled, custom] = await Promise.all([
+    api.getSystemFonts().catch((error) => {
+      console.warn('[fonts] Could not load installed fonts:', error)
+      return []
+    }),
     window.subforge.listBundledFonts().catch(() => []),
     window.subforge.listFonts().catch(() => []),
   ])
-  const all: FontInfo[] = [
-    ...bundled.map(f => ({ ...f, bundled: true  })),
-    ...custom.map( f => ({ ...f, bundled: false })),
-  ]
+  const all = mergeFontCatalogs(system, bundled, custom)
   // Fire registrations in parallel; don't block returning the list on font I/O.
   // A canvas draw that happens before a font resolves just renders in the
   // fallback face — the next draw after registration completes will use it.
-  for (const f of all) void registerFont(f.name, f.path)
+  for (const font of all) {
+    if (font.source !== 'system' && font.path) void registerFont(font.name, font.path)
+  }
   return all
 }

--- a/src/renderer/src/lib/presets.test.ts
+++ b/src/renderer/src/lib/presets.test.ts
@@ -4,9 +4,23 @@ import {
   studioToVanilla,
   applyPreset,
   BUILTIN_PRESETS,
+  getSystemFontExportWarning,
   type VanillaPreset,
 } from './presets'
 import { STUDIO_DEFAULTS, type StudioSettings } from '../components/studio/StudioPanel'
+
+describe('getSystemFontExportWarning', () => {
+  test('warns when an installed font can only travel by family name', () => {
+    expect(getSystemFontExportWarning({ font: 'Arial' })).toContain('Arial')
+  })
+
+  test('does not warn for bundled or custom font files', () => {
+    expect(
+      getSystemFontExportWarning({ font: 'Caviar Dreams', customFontPath: '/Fonts/Caviar.ttf' })
+    ).toBeNull()
+    expect(getSystemFontExportWarning({})).toBeNull()
+  })
+})
 
 // Every StudioSettings key the vanilla preset schema round-trips. Render/export
 // settings (resolution/fps/format/renderMode/bitrate/resolutionIsSource) and

--- a/src/renderer/src/lib/presets.ts
+++ b/src/renderer/src/lib/presets.ts
@@ -87,6 +87,16 @@ export interface VanillaPreset {
   safeZone?: string
 }
 
+/**
+ * System fonts are referenced by family name only; CapForge cannot safely
+ * redistribute arbitrary installed font files with an exported preset.
+ */
+export function getSystemFontExportWarning(preset: VanillaPreset): string | null {
+  const family = preset.font?.trim()
+  if (!family || preset.customFontPath?.trim()) return null
+  return `This preset uses the installed system font "${family}". The font file will not be included, so the preset may look different on a computer without that font. Export anyway?`
+}
+
 const num = (v: string | number | undefined, fallback: number): number => {
   if (v == null) return fallback
   const n = typeof v === 'number' ? v : parseFloat(v)


### PR DESCRIPTION
## Summary

- Discover and list system-installed font families alongside bundled and custom fonts.
- Replace the existing font dropdown with a searchable Adobe-style font picker.
- Keep the selected font visible and highlighted when opening the picker.
- Allow immediate filtering by typing.
- Preview fonts directly in the results list.
- Switch and preview fonts live using the Up and Down arrow keys.
- Use the same searchable picker for global subtitle styling and individual-word styling.
- Resolve the correct installed font file and weight during video rendering.
- Support common installed font files and collections, including TTF, OTF, TTC, OTC, and dfont.

## Why

CapForge previously exposed only its bundled fonts and manually uploaded fonts. Users could not conveniently select fonts already installed on their system, and the native dropdown did not provide practical searching or keyboard previewing.

## Implementation details

- Adds a cached backend system-font scanner.
- Checks standard font directories and the Windows system/per-user font registry.
- Handles multiple faces inside font collection files.
- Adds an authenticated `/api/fonts/system` endpoint.
- Fixes a renderer startup race by resolving the current backend port and local token before requesting installed fonts.
- Keeps system font entries name-based instead of treating them as uploaded custom font files.
- Adds no new third-party dependencies.

## Testing

- Frontend: 132 tests passed across 16 test files.
- System-font backend tests: 6 passed.
- TypeScript typecheck passed.
- Production Electron/Vite build passed.
- ESLint completed with 0 errors and the repository's existing 23 warnings.
- `git diff --check` passed.