### PR TITLE
Timeline inline editing: right-click word and group popups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ No test suite exists yet. The project has no linter or formatter configured.
 - `components/editor/` — SubtitleEditor (text view), GroupEditor (groups view), WordStylePopup (per-word overrides)
 - `components/player/AudioPlayer.tsx` — video/audio player with WaveSurfer waveform, canvas timeline, subtitle overlay
 - `hooks/useSubtitleOverlay.ts` — Canvas 2D subtitle preview renderer (must match backend's Pillow rendering)
-- `hooks/useTimeline.ts` — canvas-based zoomable timeline with segment drag and a word lane; double-click a word to open WordStylePopup (text correction + per-word overrides), double-click a group to open GroupPositionPopup — both popups live in ResultsScreen
+- `hooks/useTimeline.ts` — canvas-based zoomable timeline with segment drag and a word lane; right-click a word to open WordStylePopup (text correction + per-word overrides), right-click a group to open GroupPositionPopup — both popups live in ResultsScreen
 - `lib/render.ts` — builds the snake_case render config from React StudioSettings for the backend
 - `lib/groups.ts` — word grouping logic (split segments into N-word display groups)
 - `lib/presets.ts` — serialize/deserialize presets to/from StudioSettings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ No test suite exists yet. The project has no linter or formatter configured.
 - `components/editor/` — SubtitleEditor (text view), GroupEditor (groups view), WordStylePopup (per-word overrides)
 - `components/player/AudioPlayer.tsx` — video/audio player with WaveSurfer waveform, canvas timeline, subtitle overlay
 - `hooks/useSubtitleOverlay.ts` — Canvas 2D subtitle preview renderer (must match backend's Pillow rendering)
-- `hooks/useTimeline.ts` — canvas-based zoomable timeline with segment drag
+- `hooks/useTimeline.ts` — canvas-based zoomable timeline with segment drag and a word lane; double-click a word to open WordStylePopup (text correction + per-word overrides), double-click a group to open GroupPositionPopup — both popups live in ResultsScreen
 - `lib/render.ts` — builds the snake_case render config from React StudioSettings for the backend
 - `lib/groups.ts` — word grouping logic (split segments into N-word display groups)
 - `lib/presets.ts` — serialize/deserialize presets to/from StudioSettings

--- a/docs/plans/timeline-inline-editing.md
+++ b/docs/plans/timeline-inline-editing.md
@@ -189,3 +189,11 @@ Two percent sliders, live-apply, sparse `buildOverride()` (98–105) that omits 
 - Phases 1→2→3 are sequential (2 and 3 depend on 1's callbacks); 2 and 3 are independent of each other and could be parallelized in worktrees, but they both edit `ResultsScreen.tsx` — prefer sequential to avoid conflicts.
 - No backend changes anywhere in this plan. The render config and preview already consume both override types end-to-end.
 - Line numbers verified 2026-07-20 on main @ 0bbc312 — re-verify with the cited greps if main has moved.
+
+## Addendum (2026-07-21)
+
+User feedback: double-click felt clunky. The trigger changed from **double-click to right-click** (`contextmenu`), matching GroupEditor's existing right-click convention:
+
+- `useTimeline.ts`: `onWordDoubleClick`/`onGroupDoubleClick` → `onWordContextMenu`/`onGroupContextMenu`; the returned `onDoubleClick` handler → `onContextMenu`, which calls `e.preventDefault()` first to suppress the native browser context menu over the canvas. `onMouseDown` (and `onMouseUp`, which has an independent seek/deselect path for a "not dragging" release) now guard on `e.button !== 0` so a right-click never starts a drag or triggers the click-to-seek/select path — only the contextmenu handler responds to it.
+- `AudioPlayer.tsx` / `ResultsScreen.tsx`: props and handlers renamed to match (`onWordContextMenu`/`onGroupContextMenu`, `handleTimelineWordContextMenu`/`handleTimelineGroupContextMenu`); wired via React's `onContextMenu` instead of `onDoubleClick`.
+- All other behavior (popup state, lazy undo snapshots, apply/reset paths, stale-index guards) is unchanged.

--- a/docs/plans/timeline-inline-editing.md
+++ b/docs/plans/timeline-inline-editing.md
@@ -1,0 +1,191 @@
+# Timeline Inline Editing — Double-Click Word & Group Popups
+
+**Goal:** Edit directly from the canvas timeline. Double-click a **word** in the timeline word lane → popup with text correction + all per-word style overrides (color, size, transition, etc.). Double-click a **group** block → popup to change that group's position override (position_x/position_y).
+
+**Strategy:** Reuse the existing popups (`WordStylePopup`, `GroupPositionPopup`) and the existing apply paths. The only genuinely new pieces are (1) double-click detection + hit→identity mapping in `useTimeline`, (2) a text-correction field added to `WordStylePopup` (optional prop, existing call sites unaffected), and (3) popup state + apply handlers in `ResultsScreen`.
+
+Each phase is self-contained and executable in a fresh context. Verified facts below carry exact file:line references — **read the cited lines before coding; do not invent APIs.**
+
+---
+
+## Phase 0 — Documentation Discovery (COMPLETE — consolidated findings)
+
+### Architecture facts (verified 2026-07-20)
+
+**The timeline draws GROUPS, not raw segments.** `ResultsScreen.tsx:678` passes `segments={groups}` to `AudioPlayer`. Every "segment" inside `useTimeline` is a derived group (`Segment` type) with a stable-ish id `${seg.id}:${i}` from `buildStudioGroups` (`lib/groups.ts:21–59`). Map a timeline hit to a group index via `groups.findIndex(g => g.id === segId)`.
+
+**State owner is ResultsScreen**, not AudioPlayer:
+- `groups` state + `groupsEdited` flag: `ResultsScreen.tsx:70`
+- `handleGroupsPositionChange` (`ResultsScreen.tsx:222`) — position-only group updates; **must NOT flip `groupsEdited`** (comment at line 219)
+- `handleWordEdge` (`ResultsScreen.tsx:449`) — existing timeline→groups word-timing update; the pattern to copy for word override/text updates from the timeline
+- `wordStyleDefaults` memo (`ResultsScreen.tsx:547`) — already built for GroupEditor, reuse as-is
+- Undo snapshot hook: GroupEditor calls `onBeforeEdit?.()` before mutations — find ResultsScreen's equivalent near the handlers above and call it the same way
+
+### Allowed APIs (exact, verified)
+
+**`useTimeline` hook** (`src/renderer/src/hooks/useTimeline.ts`):
+- `findEdge(clientX): { segId; edge: 'start'|'end'|'body' } | null` — lines 402–419 (group hit-test)
+- `findWordHit(clientX, clientY): { wordIdx; edge } | null` — lines 432–456 (word hit-test; only valid when `selectedSegId` set and Y in word lane)
+- `isInWordLane(clientY)` — lines 421–428; word lane occupies `TOTAL_H..TOTAL_H+WORD_TRACK_H` (`WORD_TRACK_H = 24`, line 27)
+- Click-vs-drag: `movedRef` + `CLICK_SLOP_PX = 2` (line 31); mouseUp logic lines 658–678 (no-drag click → `onSeek` / selection toggle)
+- Native listener pattern with cleanup: wheel handler lines 691–720
+- Constants: `EDGE_HIT = 6` (line 28), `TOTAL_H = 52`, expanded height 76 (`AudioPlayer.tsx:34,317`)
+
+**`lib/timelineMath.ts`**: `timeToPixel(t, t0, pps)` (37–39), `clientXToTime(...)` (42–51), `computePixelsPerSecond(widthPx, visibleDur)` (32–34) — use these for computing a word/group's on-screen rect; do not re-derive the math.
+
+**`WordStylePopup`** (`src/renderer/src/components/editor/WordStylePopup.tsx:42–50`):
+```ts
+{ word, overrides: WordOverrides, anchorRect: DOMRect, defaults: WordStyleDefaults,
+  onApply(overrides), onReset(), onClose() }
+```
+Fixed-position, viewport-clamped, Escape/outside-click close built in. Reusable from anywhere that can supply a `DOMRect`. **Currently style-only — no text editing** (gap addressed in Phase 2).
+
+**`GroupPositionPopup`** (`src/renderer/src/components/editor/GroupPositionPopup.tsx:40–159`):
+```ts
+{ groupLabel, override: GroupPositionOverride, anchorRect: DOMRect,
+  defaults: GroupPositionDefaults, onApply(override), onReset(), onClose() }
+```
+Two percent sliders, live-apply, sparse `buildOverride()` (98–105) that omits axes equal to global defaults. Reusable as-is — no extraction needed.
+
+**Apply patterns to COPY (not reinvent):**
+- Word override apply: `GroupEditor.tsx:200–218` (`applyWordOverride`) — sparse storage: `overrides: Object.keys(o).length ? o : undefined`
+- Position apply: `GroupEditor.tsx:238–250` (`applyPositionOverride`) — routes through `onPositionChange`, **never** `onChange`
+- Word text edit preserving timing+overrides: `SubtitleEditor.tsx:196–209` (`{ ...seg.words[i], word }` spread)
+- Right-click→popup open pattern: `GroupEditor.tsx:191–198` / `230–236` (`anchorRect: el.getBoundingClientRect()`)
+
+**Data model** (`src/renderer/src/types/app.ts`): `WordOverrides` (8–33), `Word.overrides?` (57–63), `GroupPositionOverride` (51–54), `Segment.positionOverride?` (75).
+
+**Downstream consumers (already handle everything — no changes needed):** `lib/render.ts:151–169` sends `custom_groups` with word overrides + sparse `position_x/y` whenever `groupsEdited || hasGroupOverrides`; `useSubtitleOverlay.ts:172–178, 201–205` applies both in the preview.
+
+### Anti-pattern guards (things that do NOT exist / must not be done)
+
+- ❌ No `onWordDoubleClick`/`onGroupDoubleClick` exist yet in `UseTimelineOptions` — you are adding them; don't assume other names.
+- ❌ There is no group-position or word-style plumbing through `AudioPlayer` today — all popup/apply logic must be threaded as new props.
+- ❌ **Never call `onChange`/flip `groupsEdited` for a position-only change** — it must go through `handleGroupsPositionChange` (`ResultsScreen.tsx:219–222` comment explains why: re-grouping must keep working).
+- ❌ Don't hardcode colors — CSS vars only (`--color-*`), per CLAUDE.md theming rules.
+- ❌ Don't add a React `onWheel` — irrelevant here, but if any new native listener is needed, follow the wheel-handler cleanup pattern (`useTimeline.ts:691–720`).
+- ❌ Word identity is positional (`groupIdx` + `wordIdx`), not id-based. Close any open popup when `groups` array identity/length changes to avoid stale-index writes.
+
+### Open decisions (defaults chosen; flag to user if changing)
+
+1. **Word text correction scope:** applied to the group's word only (GroupEditor precedent) — **flips `groupsEdited`** via the normal `onChange` path, exactly like GroupEditor text edits. It does NOT mirror into source `segments`.
+2. **Double-click vs selection interplay:** a group double-click *re-selects* the group (first click of the pair may have toggled selection at `useTimeline.ts:658–678`) and then opens the popup — the popup must never open on a deselected group.
+3. **Popup render location:** `ResultsScreen` (owns state + defaults). Both popups are `position: fixed`, so tree location is irrelevant.
+
+---
+
+## Phase 1 — Double-click detection in `useTimeline` + AudioPlayer plumbing
+
+**Files:** `src/renderer/src/hooks/useTimeline.ts`, `src/renderer/src/components/player/AudioPlayer.tsx`
+
+### Implement
+
+1. Add to `UseTimelineOptions` (interface near `useTimeline.ts:48`):
+   ```ts
+   /** Double-click on a word in the open word lane. rect = word's on-screen box (viewport coords). */
+   onWordDoubleClick?: (segId: string, wordIdx: number, rect: DOMRect) => void
+   /** Double-click on a group block in the segment track. rect = group's on-screen box (viewport coords). */
+   onGroupDoubleClick?: (segId: string, rect: DOMRect) => void
+   ```
+2. Add an `onDoubleClick(e: React.MouseEvent<HTMLCanvasElement>)` handler returned by the hook (same shape as existing `onMouseDown`, lines 458–501):
+   - Ignore if a drag is in flight (`dragRef`/`wordDragRef` non-null) or `movedRef` is set.
+   - Word first (mirrors mouseDown priority, line 463): if `findWordHit(e.clientX, e.clientY)` returns a `body` hit → compute the word's viewport rect and call `onWordDoubleClick(selectedSegId, wordIdx, rect)`.
+   - Else if `findEdge(e.clientX)` returns a `body` hit → compute the group's viewport rect and call `onGroupDoubleClick(segId, rect)`.
+   - Edge hits (`'start'|'end'`) do nothing — edges are drag affordances.
+   - Rect construction: `canvas.getBoundingClientRect()` + `timeToPixel()` for start/end x, lane Y bands (ruler `RULER_H`..`TOTAL_H` for groups, `TOTAL_H`..`TOTAL_H+WORD_TRACK_H` for words) → `new DOMRect(x, y, w, h)`. Reuse `computePixelsPerSecond` — copy the conversion setup already used inside `findEdge` (402–419), do not re-derive.
+3. Wire in `AudioPlayer.tsx`:
+   - New props `onWordDoubleClick` / `onGroupDoubleClick` on `AudioPlayerProps`, passed into the `useTimeline` call (194–219).
+   - Attach the returned handler to the canvas as React `onDoubleClick` next to the existing handlers (429–439).
+   - **Selection guard (Open decision #2):** in the group double-click path, call `setSelectedGroupId(segId)` before forwarding, so the pair's first-click toggle can't leave the popup targeting a deselected group. Read `useTimeline.ts:658–678` first to confirm exactly when the toggle fires and note the finding in the commit message.
+
+### Verify
+
+- [ ] `npm run typecheck` clean.
+- [ ] Add unit tests beside the existing timeline tests (`git grep -l timelineMath src/renderer` to locate the test file/pattern) for the rect computation (time↔pixel round-trip for a known zoom/scroll).
+- [ ] Grep guard: `grep -n "onDoubleClick" src/renderer/src/hooks/useTimeline.ts src/renderer/src/components/player/AudioPlayer.tsx` shows hook + canvas wiring.
+- [ ] Manual: `npm run dev:react` — double-click logs (temporary `console.log` removed before commit) fire with correct segId/wordIdx; drag still works; click-to-seek still works; wheel zoom/pan unaffected.
+
+### Anti-pattern guards
+
+- Do not open popups from inside the hook — the hook only reports hits (keeps it renderer-agnostic like every other callback it has).
+- Do not break the `movedRef`/`CLICK_SLOP_PX` click-vs-drag logic; double-click handling must be additive.
+
+---
+
+## Phase 2 — Word popup: text correction + style overrides
+
+**Files:** `src/renderer/src/components/editor/WordStylePopup.tsx`, `src/renderer/src/components/screens/ResultsScreen.tsx`
+
+### Implement
+
+1. **Extend `WordStylePopup` with optional text editing** (existing call site in GroupEditor must keep compiling without changes):
+   ```ts
+   /** When set, shows an editable text field for the word; called on commit (Enter/blur). */
+   onTextCommit?: (newText: string) => void
+   ```
+   Render a text input at the top of the popup (above the style controls) only when `onTextCommit` is provided. Trim; ignore empty commits. Follow the popup's existing input styling (CSS vars, see its color/size rows) — no hardcoded colors.
+2. **ResultsScreen popup state + handlers:**
+   - State: `const [wordPopup, setWordPopup] = useState<{ groupIdx: number; wordIdx: number; anchorRect: DOMRect } | null>(null)`
+   - `onWordDoubleClick(segId, wordIdx, rect)` (passed to `<AudioPlayer>` at ~line 675): resolve `groupIdx = groups.findIndex(g => g.id === segId)`; bail if `-1`; set state.
+   - Apply override: copy `applyWordOverride` from `GroupEditor.tsx:200–218` verbatim, adapted to ResultsScreen's `groups`/`setGroups` + undo-snapshot call — route through the same path `handleWordEdge` (449) uses so `groupsEdited` semantics match word-timing edits. **Read `handleWordEdge` first and mirror its update mechanics exactly.**
+   - Text commit: copy the word-spread pattern from `SubtitleEditor.tsx:196–209` — update `groups[gi].words[wi].word` via `{ ...w, word: newText }` AND rebuild the group's `text` by joining word strings; flows through the same `onChange`-equivalent path (flips `groupsEdited`, Open decision #1).
+   - Reset: apply `{}` (the sparse-storage line converts it to `undefined`).
+   - Close on: popup `onClose`, and a `useEffect` clearing `wordPopup` whenever `groups.length` changes or the target index vanishes (stale-index guard from Phase 0).
+   - Render `<WordStylePopup>` at ResultsScreen root, fed by the existing `wordStyleDefaults` memo (547).
+3. Live preview works for free: `onApply` mutates `groups` → `useSubtitleOverlay` re-renders (`useSubtitleOverlay.ts:172–178`).
+
+### Verify
+
+- [ ] `npm run typecheck` clean; frontend test suite green (same command CI uses — check `.github/workflows` / `package.json` `test` script).
+- [ ] GroupEditor's existing WordStylePopup usage unchanged: `grep -n "WordStylePopup" src/renderer/src -r` — GroupEditor call site has no new required props.
+- [ ] Manual: double-click word in timeline lane → popup at word; change color → preview updates live; correct text → word text updates in timeline + preview + Groups editor; Reset clears; Escape/outside-click closes; Cmd+Z undoes.
+- [ ] Render path: after an override, `buildRenderBody` output contains the override inside `custom_groups` words (assert via existing render.ts tests pattern — `git grep -l buildRenderBody src/renderer --include='*.test.*'`).
+
+### Anti-pattern guards
+
+- Do not fork a second word-style popup component — one component, optional prop.
+- Do not write overrides to source `segments` — they live on the group's word objects (Phase 0 data model).
+- Text commit must preserve `start`/`end`/`overrides` on the word (spread pattern) — replacing the word object wholesale loses timing.
+
+---
+
+## Phase 3 — Group popup: position override
+
+**Files:** `src/renderer/src/components/screens/ResultsScreen.tsx` (only — popup + hook work already done)
+
+### Implement
+
+1. State: `const [groupPosPopup, setGroupPosPopup] = useState<{ groupIdx: number; anchorRect: DOMRect } | null>(null)`
+2. `onGroupDoubleClick(segId, rect)` → resolve index by `g.id`, set state.
+3. Apply: copy `applyPositionOverride` from `GroupEditor.tsx:238–250` — but call `handleGroupsPositionChange` (`ResultsScreen.tsx:222`) directly (it IS the `onPositionChange` target GroupEditor uses via props, see line 657). **This is the whole reason position edits don't flip `groupsEdited` — do not route through the boundary-edit path.**
+4. `GroupPositionDefaults`: build from settings the same way GroupEditor's call site does — find GroupEditor's popup render (`grep -n "GroupPositionPopup" src/renderer/src/components/editor/GroupEditor.tsx`) and copy the defaults construction.
+5. `groupLabel`: mirror GroupEditor's label format (`#N` + text excerpt).
+6. Same stale-index close guard as Phase 2; render `<GroupPositionPopup>` at ResultsScreen root.
+
+### Verify
+
+- [ ] `npm run typecheck` clean; frontend tests green.
+- [ ] **The critical invariant:** set a position override via timeline double-click, then change words-per-group in StudioPanel → re-grouping still happens (i.e., `groupsEdited` stayed false). This is the regression the `onPositionChange` split exists to prevent.
+- [ ] Manual: double-click group block → popup; sliders move caption live in preview; Reset returns to global position; `⌖` indicator appears on the group row in the Groups editor (existing UI, `GroupEditor.tsx:476–491`); override survives project save/load.
+- [ ] Grep guard: `grep -n "groupsEdited" src/renderer/src/components/screens/ResultsScreen.tsx` — confirm no new `setGroupsEdited(true)` was added in the position path.
+
+---
+
+## Phase 4 — Final verification & docs
+
+1. **Full gates:** `npm run typecheck` + complete frontend test run + (if any backend-touching change crept in — it should NOT have) `pytest`. No backend or parity-suite changes are expected in this feature; if any renderer formula was touched, STOP — that's out of scope (Preview ↔ Render parity contract in CLAUDE.md).
+2. **Anti-pattern sweep:**
+   - `grep -rn "text-white\|bg-black" src/renderer/src/components/editor src/renderer/src/components/player` → no new hits.
+   - `grep -n "onChange" ResultsScreen.tsx` position path → confirm position flows only through `handleGroupsPositionChange`.
+   - `grep -rn "console.log" src/renderer/src/hooks/useTimeline.ts` → none.
+3. **Interaction regression checklist** (manual, `npm run dev:react`): word drag/snapping, segment edge drag, click-to-seek, selection toggle, Escape deselect, wheel zoom/pan, Cmd+Z on both popup edit types, both themes (popups use CSS vars — verify light mode).
+4. Update `CLAUDE.md` Renderer Structure bullet for the timeline if behavior description changed; note the new `useTimeline` callbacks.
+5. Commit via `git-ops` agent (conventional commits, feature branch off main).
+
+---
+
+## Execution notes
+
+- Phases 1→2→3 are sequential (2 and 3 depend on 1's callbacks); 2 and 3 are independent of each other and could be parallelized in worktrees, but they both edit `ResultsScreen.tsx` — prefer sequential to avoid conflicts.
+- No backend changes anywhere in this plan. The render config and preview already consume both override types end-to-end.
+- Line numbers verified 2026-07-20 on main @ 0bbc312 — re-verify with the cited greps if main has moved.

--- a/src/renderer/src/components/editor/WordStylePopup.test.tsx
+++ b/src/renderer/src/components/editor/WordStylePopup.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Static-markup tests (node env, react-dom/server) for the optional
+ * onTextCommit text field — see docs/plans/timeline-inline-editing.md Phase 2.
+ *
+ * `popupStyle` reads `window.innerWidth`/`innerHeight` synchronously during
+ * render (not inside an effect), so — unlike components that only touch
+ * `window` from effects — this component needs `window` stubbed even under
+ * renderToStaticMarkup. `loadAllFonts()` runs in a useEffect and does NOT run
+ * under renderToStaticMarkup, so no font-loading mock is needed (same
+ * reasoning as HyperFramesPanel.test.tsx).
+ *
+ * Only rendering (presence/absence/initial value) is asserted here — this
+ * harness has no jsdom/testing-library, so it cannot simulate the
+ * Enter/blur commit interactions. See the session report for what remains
+ * unverified by automated tests.
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { WordStylePopup, type WordStyleDefaults } from './WordStylePopup'
+
+const DEFAULTS: WordStyleDefaults = {
+  textColor: '#FFFFFF',
+  activeColor: '#D4952A',
+}
+
+function fakeRect(): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 40,
+    height: 20,
+    top: 100,
+    left: 100,
+    right: 140,
+    bottom: 120,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+beforeEach(() => {
+  vi.stubGlobal('window', { innerWidth: 1280, innerHeight: 800 })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('WordStylePopup — onTextCommit text field', () => {
+  test('renders no text field when onTextCommit is omitted (GroupEditor call site)', () => {
+    const html = renderToStaticMarkup(
+      <WordStylePopup
+        word="hello"
+        overrides={{}}
+        anchorRect={fakeRect()}
+        defaults={DEFAULTS}
+        onApply={vi.fn()}
+        onReset={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(html).not.toContain('value="hello"')
+  })
+
+  test('renders an editable text field initialized to the word when onTextCommit is provided', () => {
+    const html = renderToStaticMarkup(
+      <WordStylePopup
+        word="hello"
+        overrides={{}}
+        anchorRect={fakeRect()}
+        defaults={DEFAULTS}
+        onApply={vi.fn()}
+        onReset={vi.fn()}
+        onClose={vi.fn()}
+        onTextCommit={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('type="text"')
+    expect(html).toContain('value="hello"')
+    // The label row sits above the existing style controls (text color row).
+    expect(html.indexOf('>Text<')).toBeGreaterThanOrEqual(0)
+    expect(html.indexOf('>Text<')).toBeLessThan(html.indexOf('>Text color<'))
+  })
+})

--- a/src/renderer/src/components/editor/WordStylePopup.test.tsx
+++ b/src/renderer/src/components/editor/WordStylePopup.test.tsx
@@ -13,6 +13,16 @@
  * harness has no jsdom/testing-library, so it cannot simulate the
  * Enter/blur commit interactions. See the session report for what remains
  * unverified by automated tests.
+ *
+ * Invariant (outside-click vs. portaled FontCombobox dropdown): the
+ * component's document-level `mousedown` outside-click closer must ignore
+ * any element inside `[data-cf-popover]` — FontCombobox portals its option
+ * list to document.body, outside this popup's own `popupRef`, so without the
+ * guard a mousedown on a font option would close/unmount this popup before
+ * FontCombobox's `onClick`-based selection commits. Exercising that requires
+ * a real mousedown dispatched at document level plus the dropdown actually
+ * open (jsdom + testing-library), which this renderToStaticMarkup harness
+ * cannot do — skipped here rather than faked.
  */
 
 import { renderToStaticMarkup } from 'react-dom/server'

--- a/src/renderer/src/components/editor/WordStylePopup.tsx
+++ b/src/renderer/src/components/editor/WordStylePopup.tsx
@@ -167,6 +167,13 @@ export function WordStylePopup({
   // Close on outside click or Escape.
   useEffect(() => {
     function onMouseDown(e: MouseEvent) {
+      // The font combobox portals its dropdown list to document.body, so it
+      // sits outside popupRef in the DOM tree. Containment against popupRef
+      // alone would treat a mousedown on one of its options as an "outside"
+      // click and close this popup before FontCombobox's own onSelect (which
+      // fires on click) commits the selection. Ignore any portaled popover.
+      const el = e.target instanceof Element ? e.target : null
+      if (el?.closest('[data-cf-popover]')) return
       if (popupRef.current && !popupRef.current.contains(e.target as Node)) onClose()
     }
     function onKey(e: KeyboardEvent) {

--- a/src/renderer/src/components/editor/WordStylePopup.tsx
+++ b/src/renderer/src/components/editor/WordStylePopup.tsx
@@ -47,6 +47,10 @@ interface WordStylePopupProps {
   onApply: (overrides: WordOverrides) => void
   onReset: () => void
   onClose: () => void
+  /** When set, shows an editable text field for the word above the style
+   *  controls; called on commit (Enter/blur) with the trimmed new text.
+   *  Omitted → no text field renders (existing call sites unaffected). */
+  onTextCommit?: (newText: string) => void
 }
 
 // Vanilla's word-level transitions.
@@ -80,9 +84,11 @@ export function WordStylePopup({
   onApply,
   onReset,
   onClose,
+  onTextCommit,
 }: WordStylePopupProps) {
   // Local edit state — only committed on Apply. Reflect the override if set,
   // otherwise fall back to the global default for nice initial values.
+  const [textDraft, setTextDraft] = useState(word)
   const [textColor, setTextColor] = useState(overrides.text_color ?? defaults.textColor)
   const [activeColor, setActiveColor] = useState(
     overrides.active_word_color ?? defaults.activeColor
@@ -255,6 +261,15 @@ export function WordStylePopup({
     return next
   }
 
+  // Commit the text field — on Enter and on blur. Trims; ignores empty or
+  // unchanged commits so an accidental Enter/blur doesn't emit a no-op edit.
+  function commitText() {
+    if (!onTextCommit) return
+    const trimmed = textDraft.trim()
+    if (!trimmed || trimmed === word) return
+    onTextCommit(trimmed)
+  }
+
   function handleApply() {
     onApply(buildOverrides())
     onClose()
@@ -301,6 +316,26 @@ export function WordStylePopup({
       </div>
 
       <div className="flex flex-col gap-2 overflow-y-auto pr-1 min-h-0">
+        {onTextCommit && (
+          <div className="flex items-center gap-2">
+            <label className="w-20 shrink-0" style={{ color: 'var(--color-text-2)' }}>
+              Text
+            </label>
+            <input
+              type="text"
+              value={textDraft}
+              onChange={(e) => setTextDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  commitText()
+                }
+              }}
+              onBlur={commitText}
+              className="flex-1 min-w-0 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs"
+            />
+          </div>
+        )}
         <ColorRow label="Text color" value={textColor} onChange={setTextColor} />
         <ColorRow label="Active color" value={activeColor} onChange={setActiveColor} />
 

--- a/src/renderer/src/components/player/AudioPlayer.tsx
+++ b/src/renderer/src/components/player/AudioPlayer.tsx
@@ -55,6 +55,10 @@ interface AudioPlayerProps {
   onWordEdge?: (segId: string, wordIdx: number, patch: { start: number; end: number }) => void
   /** Called once when a word drag begins (before any movement). */
   onWordEdgeDragStart?: (segId: string, wordIdx: number) => void
+  /** Called on double-click of a word in the open timeline word lane. */
+  onWordDoubleClick?: (segId: string, wordIdx: number, rect: DOMRect) => void
+  /** Called on double-click of a group block in the timeline segment track. */
+  onGroupDoubleClick?: (segId: string, rect: DOMRect) => void
 }
 
 export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(function AudioPlayer(
@@ -71,6 +75,8 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
     onSegmentEdgeDragStart,
     onWordEdge,
     onWordEdgeDragStart,
+    onWordDoubleClick,
+    onGroupDoubleClick,
   },
   ref
 ) {
@@ -197,6 +203,7 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
     onMouseMove,
     onMouseUp,
     onMouseLeave: onCanvasLeave,
+    onDoubleClick: onCanvasDoubleClick,
     setZoom: setTlZoom,
     setScroll: setTlScroll,
   } = useTimeline({
@@ -216,6 +223,19 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
     }, []),
     onZoomChange: (z, s) => syncWaveformRef.current(z, s),
     onScrollChange: (s, z) => syncWaveformRef.current(z, s),
+    onWordDoubleClick,
+    // Selection guard: the double-click's first mouseup toggles selection via
+    // onSelectSegment (useTimeline.ts onMouseUp, ~line 658) — if the group was
+    // already selected, that first click's mouseup deselects it, so by the time
+    // the browser fires dblclick the group can be deselected again. Force
+    // re-select before forwarding so the popup never targets a stale/deselected group.
+    onGroupDoubleClick: useCallback(
+      (segId: string, rect: DOMRect) => {
+        setSelectedGroupId(segId)
+        onGroupDoubleClick?.(segId, rect)
+      },
+      [onGroupDoubleClick]
+    ),
   })
   // Keep refs current every render so WaveSurfer callbacks are never stale.
   timelineDrawRef.current = timelineDraw
@@ -437,6 +457,7 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
             onCanvasLeave()
             setHoverState(null)
           }}
+          onDoubleClick={onCanvasDoubleClick}
         />
         {/* Phase 2: Hover tooltip */}
         {hoverState && (

--- a/src/renderer/src/components/player/AudioPlayer.tsx
+++ b/src/renderer/src/components/player/AudioPlayer.tsx
@@ -55,10 +55,10 @@ interface AudioPlayerProps {
   onWordEdge?: (segId: string, wordIdx: number, patch: { start: number; end: number }) => void
   /** Called once when a word drag begins (before any movement). */
   onWordEdgeDragStart?: (segId: string, wordIdx: number) => void
-  /** Called on double-click of a word in the open timeline word lane. */
-  onWordDoubleClick?: (segId: string, wordIdx: number, rect: DOMRect) => void
-  /** Called on double-click of a group block in the timeline segment track. */
-  onGroupDoubleClick?: (segId: string, rect: DOMRect) => void
+  /** Called on right-click of a word in the open timeline word lane. */
+  onWordContextMenu?: (segId: string, wordIdx: number, rect: DOMRect) => void
+  /** Called on right-click of a group block in the timeline segment track. */
+  onGroupContextMenu?: (segId: string, rect: DOMRect) => void
 }
 
 export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(function AudioPlayer(
@@ -75,8 +75,8 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
     onSegmentEdgeDragStart,
     onWordEdge,
     onWordEdgeDragStart,
-    onWordDoubleClick,
-    onGroupDoubleClick,
+    onWordContextMenu,
+    onGroupContextMenu,
   },
   ref
 ) {
@@ -203,7 +203,7 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
     onMouseMove,
     onMouseUp,
     onMouseLeave: onCanvasLeave,
-    onDoubleClick: onCanvasDoubleClick,
+    onContextMenu: onCanvasContextMenu,
     setZoom: setTlZoom,
     setScroll: setTlScroll,
   } = useTimeline({
@@ -223,18 +223,15 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
     }, []),
     onZoomChange: (z, s) => syncWaveformRef.current(z, s),
     onScrollChange: (s, z) => syncWaveformRef.current(z, s),
-    onWordDoubleClick,
-    // Selection guard: the double-click's first mouseup toggles selection via
-    // onSelectSegment (useTimeline.ts onMouseUp, ~line 658) — if the group was
-    // already selected, that first click's mouseup deselects it, so by the time
-    // the browser fires dblclick the group can be deselected again. Force
-    // re-select before forwarding so the popup never targets a stale/deselected group.
-    onGroupDoubleClick: useCallback(
+    onWordContextMenu,
+    // Right-click selects the group so the word lane opens and the popup
+    // always targets a selected group.
+    onGroupContextMenu: useCallback(
       (segId: string, rect: DOMRect) => {
         setSelectedGroupId(segId)
-        onGroupDoubleClick?.(segId, rect)
+        onGroupContextMenu?.(segId, rect)
       },
-      [onGroupDoubleClick]
+      [onGroupContextMenu]
     ),
   })
   // Keep refs current every render so WaveSurfer callbacks are never stale.
@@ -457,7 +454,7 @@ export const AudioPlayer = forwardRef<AudioPlayerHandle, AudioPlayerProps>(funct
             onCanvasLeave()
             setHoverState(null)
           }}
-          onDoubleClick={onCanvasDoubleClick}
+          onContextMenu={onCanvasContextMenu}
         />
         {/* Phase 2: Hover tooltip */}
         {hoverState && (

--- a/src/renderer/src/components/screens/ResultsScreen.tsx
+++ b/src/renderer/src/components/screens/ResultsScreen.tsx
@@ -80,7 +80,7 @@ export function ResultsScreen({
   // Transient: when set, SubtitleEditor scrolls/focuses that segment's text
   // field (used right after a manual "+ Add subtitle" so the user can type).
   const [focusSegmentId, setFocusSegmentId] = useState<string | null>(null)
-  // Timeline double-click on a word in the word lane → style/text popup.
+  // Timeline right-click on a word in the word lane → style/text popup.
   // Word identity is positional (groupIdx + wordIdx), not id-based — see the
   // stale-index guard effect below.
   const [wordPopup, setWordPopup] = useState<{
@@ -88,7 +88,7 @@ export function ResultsScreen({
     wordIdx: number
     anchorRect: DOMRect
   } | null>(null)
-  // Timeline double-click on a group block → position-override popup. Group
+  // Timeline right-click on a group block → position-override popup. Group
   // identity is positional (groupIdx), not id-based — see the stale-index
   // guard effect below (mirrors the word popup's guard).
   const [groupPosPopup, setGroupPosPopup] = useState<{
@@ -492,7 +492,7 @@ export function ResultsScreen({
     pushUndo()
   }, [pushUndo])
 
-  // Timeline word lane double-click → open the style/text popup for that
+  // Timeline word lane right-click → open the style/text popup for that
   // word. One undo snapshot per popup "session" (mirrors the drag-start
   // pattern above) rather than one per keystroke/slider tick — the popup's
   // onApply fires continuously while it's open. The snapshot itself is taken
@@ -500,7 +500,7 @@ export function ResultsScreen({
   // inspect-only open/close (Escape, outside click, no edits) doesn't push a
   // no-op undo entry.
   const wordPopupUndoPushedRef = useRef(false)
-  const handleTimelineWordDoubleClick = useCallback(
+  const handleTimelineWordContextMenu = useCallback(
     (segId: string, wordIdx: number, rect: DOMRect) => {
       const groupIdx = groups.findIndex((g) => g.id === segId)
       if (groupIdx === -1) return
@@ -562,12 +562,12 @@ export function ResultsScreen({
     [pushUndo]
   )
 
-  // Timeline group block double-click → open the position-override popup for
+  // Timeline group block right-click → open the position-override popup for
   // that group. Same lazy one-snapshot-per-session undo pattern as the word
   // popup above (wordPopupUndoPushedRef) rather than GroupEditor's per-apply
   // onBeforeEdit — the popup's onApply fires continuously while sliders move.
   const groupPosUndoPushedRef = useRef(false)
-  const handleTimelineGroupDoubleClick = useCallback(
+  const handleTimelineGroupContextMenu = useCallback(
     (segId: string, rect: DOMRect) => {
       const groupIdx = groups.findIndex((g) => g.id === segId)
       if (groupIdx === -1) return
@@ -833,8 +833,8 @@ export function ResultsScreen({
           onSegmentEdgeDragStart={handleSegmentEdgeDragStart}
           onWordEdge={handleWordEdge}
           onWordEdgeDragStart={handleWordEdgeDragStart}
-          onWordDoubleClick={handleTimelineWordDoubleClick}
-          onGroupDoubleClick={handleTimelineGroupDoubleClick}
+          onWordContextMenu={handleTimelineWordContextMenu}
+          onGroupContextMenu={handleTimelineGroupContextMenu}
         />
       </div>
 

--- a/src/renderer/src/components/screens/ResultsScreen.tsx
+++ b/src/renderer/src/components/screens/ResultsScreen.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { TranscriptionResult, Segment } from '../../types/app'
+import type { TranscriptionResult, Segment, WordOverrides } from '../../types/app'
 import { buildStudioGroups, fillGroupGaps } from '../../lib/groups'
 import type { ProjectFile, ProjectIOHandle, WordOverrideEdit } from '../../lib/project'
 import { PROJECT_VERSION, suggestProjectName } from '../../lib/project'
@@ -23,7 +23,7 @@ import { AudioPlayer, type AudioPlayerHandle } from '../player/AudioPlayer'
 import { AlignmentNotice } from './AlignmentNotice'
 import { SubtitleEditor } from '../editor/SubtitleEditor'
 import { GroupEditor } from '../editor/GroupEditor'
-import type { WordStyleDefaults } from '../editor/WordStylePopup'
+import { WordStylePopup, type WordStyleDefaults } from '../editor/WordStylePopup'
 import type { StudioSettings } from '../studio/StudioPanel'
 
 interface ResultsScreenProps {
@@ -74,6 +74,14 @@ export function ResultsScreen({
   // Transient: when set, SubtitleEditor scrolls/focuses that segment's text
   // field (used right after a manual "+ Add subtitle" so the user can type).
   const [focusSegmentId, setFocusSegmentId] = useState<string | null>(null)
+  // Timeline double-click on a word in the word lane → style/text popup.
+  // Word identity is positional (groupIdx + wordIdx), not id-based — see the
+  // stale-index guard effect below.
+  const [wordPopup, setWordPopup] = useState<{
+    groupIdx: number
+    wordIdx: number
+    anchorRect: DOMRect
+  } | null>(null)
   const [editorWidth, setEditorWidth] = useState(420)
   // Segment id currently being re-aligned via /api/realign (null = idle).
   const [realigningSegId, setRealigningSegId] = useState<string | null>(null)
@@ -471,6 +479,85 @@ export function ResultsScreen({
     pushUndo()
   }, [pushUndo])
 
+  // Timeline word lane double-click → open the style/text popup for that
+  // word. One undo snapshot per popup "session" (mirrors the drag-start
+  // pattern above) rather than one per keystroke/slider tick — the popup's
+  // onApply fires continuously while it's open. The snapshot itself is taken
+  // lazily on the first real change (see wordPopupUndoPushedRef below) so an
+  // inspect-only open/close (Escape, outside click, no edits) doesn't push a
+  // no-op undo entry.
+  const wordPopupUndoPushedRef = useRef(false)
+  const handleTimelineWordDoubleClick = useCallback(
+    (segId: string, wordIdx: number, rect: DOMRect) => {
+      const groupIdx = groups.findIndex((g) => g.id === segId)
+      if (groupIdx === -1) return
+      wordPopupUndoPushedRef.current = false
+      setWordPopup({ groupIdx, wordIdx, anchorRect: rect })
+    },
+    [groups]
+  )
+
+  // Style override apply/reset for the timeline word popup — same sparse-
+  // storage + groupsEdited mechanics as handleWordEdge (setGroups directly,
+  // flip groupsEdited). The undo snapshot is pushed once, on the first apply
+  // of the popup session (see wordPopupUndoPushedRef above).
+  const applyTimelineWordOverride = useCallback(
+    (gi: number, wi: number, overrides: WordOverrides) => {
+      if (!wordPopupUndoPushedRef.current) {
+        pushUndo()
+        wordPopupUndoPushedRef.current = true
+      }
+      setGroups((prev) =>
+        prev.map((g, idx) =>
+          idx !== gi
+            ? g
+            : {
+                ...g,
+                words: g.words.map((w, j) =>
+                  j !== wi
+                    ? w
+                    : { ...w, overrides: Object.keys(overrides).length ? overrides : undefined }
+                ),
+              }
+        )
+      )
+      setGroupsEdited(true)
+    },
+    [pushUndo]
+  )
+
+  // Text correction from the timeline word popup — preserves start/end/
+  // overrides via spread (SubtitleEditor.tsx's word-edit pattern) and rebuilds
+  // the group's joined text. A boundary-locking edit (Open decision #1): it
+  // flips groupsEdited exactly like GroupEditor/SubtitleEditor text edits.
+  // Same lazy one-snapshot-per-session undo push as applyTimelineWordOverride.
+  const applyTimelineWordText = useCallback(
+    (gi: number, wi: number, newText: string) => {
+      if (!wordPopupUndoPushedRef.current) {
+        pushUndo()
+        wordPopupUndoPushedRef.current = true
+      }
+      setGroups((prev) =>
+        prev.map((g, idx) => {
+          if (idx !== gi) return g
+          const words = g.words.map((w, j) => (j !== wi ? w : { ...w, word: newText }))
+          return { ...g, words, text: words.map((w) => w.word).join(' ') }
+        })
+      )
+      setGroupsEdited(true)
+    },
+    [pushUndo]
+  )
+
+  // Stale-index guard: close the popup if the groups array changed shape
+  // (re-grouping, merge/split, undo/redo) such that the target word no
+  // longer exists — word identity here is positional, not id-based.
+  useEffect(() => {
+    if (wordPopup && !groups[wordPopup.groupIdx]?.words[wordPopup.wordIdx]) {
+      setWordPopup(null)
+    }
+  }, [groups, wordPopup])
+
   // Re-run WhisperX forced alignment on one segment. The backend re-fits word
   // timings to the audio; per-word style overrides are re-attached by index
   // (the backend preserves word count).
@@ -686,8 +773,24 @@ export function ResultsScreen({
           onSegmentEdgeDragStart={handleSegmentEdgeDragStart}
           onWordEdge={handleWordEdge}
           onWordEdgeDragStart={handleWordEdgeDragStart}
+          onWordDoubleClick={handleTimelineWordDoubleClick}
         />
       </div>
+
+      {wordPopup && groups[wordPopup.groupIdx]?.words[wordPopup.wordIdx] && (
+        <WordStylePopup
+          word={groups[wordPopup.groupIdx].words[wordPopup.wordIdx].word}
+          overrides={groups[wordPopup.groupIdx].words[wordPopup.wordIdx].overrides ?? {}}
+          anchorRect={wordPopup.anchorRect}
+          defaults={wordStyleDefaults}
+          onApply={(ov) => applyTimelineWordOverride(wordPopup.groupIdx, wordPopup.wordIdx, ov)}
+          onReset={() => applyTimelineWordOverride(wordPopup.groupIdx, wordPopup.wordIdx, {})}
+          onTextCommit={(newText) =>
+            applyTimelineWordText(wordPopup.groupIdx, wordPopup.wordIdx, newText)
+          }
+          onClose={() => setWordPopup(null)}
+        />
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/screens/ResultsScreen.tsx
+++ b/src/renderer/src/components/screens/ResultsScreen.tsx
@@ -12,7 +12,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { TranscriptionResult, Segment, WordOverrides } from '../../types/app'
+import type {
+  TranscriptionResult,
+  Segment,
+  WordOverrides,
+  GroupPositionOverride,
+} from '../../types/app'
 import { buildStudioGroups, fillGroupGaps } from '../../lib/groups'
 import type { ProjectFile, ProjectIOHandle, WordOverrideEdit } from '../../lib/project'
 import { PROJECT_VERSION, suggestProjectName } from '../../lib/project'
@@ -24,6 +29,7 @@ import { AlignmentNotice } from './AlignmentNotice'
 import { SubtitleEditor } from '../editor/SubtitleEditor'
 import { GroupEditor } from '../editor/GroupEditor'
 import { WordStylePopup, type WordStyleDefaults } from '../editor/WordStylePopup'
+import { GroupPositionPopup } from '../editor/GroupPositionPopup'
 import type { StudioSettings } from '../studio/StudioPanel'
 
 interface ResultsScreenProps {
@@ -80,6 +86,13 @@ export function ResultsScreen({
   const [wordPopup, setWordPopup] = useState<{
     groupIdx: number
     wordIdx: number
+    anchorRect: DOMRect
+  } | null>(null)
+  // Timeline double-click on a group block → position-override popup. Group
+  // identity is positional (groupIdx), not id-based — see the stale-index
+  // guard effect below (mirrors the word popup's guard).
+  const [groupPosPopup, setGroupPosPopup] = useState<{
+    groupIdx: number
     anchorRect: DOMRect
   } | null>(null)
   const [editorWidth, setEditorWidth] = useState(420)
@@ -549,6 +562,45 @@ export function ResultsScreen({
     [pushUndo]
   )
 
+  // Timeline group block double-click → open the position-override popup for
+  // that group. Same lazy one-snapshot-per-session undo pattern as the word
+  // popup above (wordPopupUndoPushedRef) rather than GroupEditor's per-apply
+  // onBeforeEdit — the popup's onApply fires continuously while sliders move.
+  const groupPosUndoPushedRef = useRef(false)
+  const handleTimelineGroupDoubleClick = useCallback(
+    (segId: string, rect: DOMRect) => {
+      const groupIdx = groups.findIndex((g) => g.id === segId)
+      if (groupIdx === -1) return
+      groupPosUndoPushedRef.current = false
+      setGroupPosPopup({ groupIdx, anchorRect: rect })
+    },
+    [groups]
+  )
+
+  // Position-override apply/reset for the timeline group popup — mirrors
+  // GroupEditor's applyPositionOverride (sparse storage: an override with no
+  // keys collapses to undefined) but routes through handleGroupsPositionChange
+  // instead of the boundary-edit path, so groupsEdited is never flipped — a
+  // position override doesn't change group boundaries, and re-grouping must
+  // keep working. The undo snapshot is pushed once, lazily, on the first
+  // apply of the popup session (see groupPosUndoPushedRef above).
+  const applyTimelineGroupPosition = useCallback(
+    (gi: number, override: GroupPositionOverride) => {
+      if (!groupPosUndoPushedRef.current) {
+        pushUndo()
+        groupPosUndoPushedRef.current = true
+      }
+      handleGroupsPositionChange(
+        groups.map((g, idx) =>
+          idx !== gi
+            ? g
+            : { ...g, positionOverride: Object.keys(override).length ? override : undefined }
+        )
+      )
+    },
+    [groups, handleGroupsPositionChange, pushUndo]
+  )
+
   // Stale-index guard: close the popup if the groups array changed shape
   // (re-grouping, merge/split, undo/redo) such that the target word no
   // longer exists — word identity here is positional, not id-based.
@@ -557,6 +609,14 @@ export function ResultsScreen({
       setWordPopup(null)
     }
   }, [groups, wordPopup])
+
+  // Same stale-index guard for the group position popup — group identity is
+  // also positional (groupIdx), not id-based.
+  useEffect(() => {
+    if (groupPosPopup && !groups[groupPosPopup.groupIdx]) {
+      setGroupPosPopup(null)
+    }
+  }, [groups, groupPosPopup])
 
   // Re-run WhisperX forced alignment on one segment. The backend re-fits word
   // timings to the audio; per-word style overrides are re-attached by index
@@ -774,6 +834,7 @@ export function ResultsScreen({
           onWordEdge={handleWordEdge}
           onWordEdgeDragStart={handleWordEdgeDragStart}
           onWordDoubleClick={handleTimelineWordDoubleClick}
+          onGroupDoubleClick={handleTimelineGroupDoubleClick}
         />
       </div>
 
@@ -789,6 +850,18 @@ export function ResultsScreen({
             applyTimelineWordText(wordPopup.groupIdx, wordPopup.wordIdx, newText)
           }
           onClose={() => setWordPopup(null)}
+        />
+      )}
+
+      {groupPosPopup && groups[groupPosPopup.groupIdx] && (
+        <GroupPositionPopup
+          groupLabel={`#${groupPosPopup.groupIdx + 1} ${groups[groupPosPopup.groupIdx].text}`}
+          override={groups[groupPosPopup.groupIdx].positionOverride ?? {}}
+          anchorRect={groupPosPopup.anchorRect}
+          defaults={{ posX: settings.posX, posY: settings.posY }}
+          onApply={(ov) => applyTimelineGroupPosition(groupPosPopup.groupIdx, ov)}
+          onReset={() => applyTimelineGroupPosition(groupPosPopup.groupIdx, {})}
+          onClose={() => setGroupPosPopup(null)}
         />
       )}
     </div>

--- a/src/renderer/src/components/ui/FontCombobox.test.tsx
+++ b/src/renderer/src/components/ui/FontCombobox.test.tsx
@@ -3,6 +3,15 @@ import { describe, expect, test, vi } from 'vitest'
 import type { FontInfo } from '../../lib/fonts'
 import { filterFonts, FontCombobox, resolveFontSelection } from './FontCombobox'
 
+// Invariant: the portaled dropdown (rendered only while `open`, via
+// createPortal to document.body) must always carry `data-cf-popover` — any
+// ancestor popup with its own document-level outside-click closer relies on
+// that marker to avoid treating a click on an option as "outside" (see
+// WordStylePopup's onMouseDown guard). This static-markup harness never sets
+// `open` to true (that requires a real click + effect run under jsdom), so it
+// cannot render the portal or assert the attribute — documenting the
+// invariant here instead of forcing a fake test.
+
 const FONTS: FontInfo[] = [
   { name: 'Arial', path: '', source: 'system' },
   { name: 'Caviar Dreams', path: '/bundle/caviar.ttf', source: 'bundled' },

--- a/src/renderer/src/components/ui/FontCombobox.tsx
+++ b/src/renderer/src/components/ui/FontCombobox.tsx
@@ -236,10 +236,15 @@ export function FontCombobox({
         />
       </svg>
 
+      {/* Portaled to document.body (below), so any ancestor popup with its own
+          "outside click closes" handler must ignore clicks in here via
+          [data-cf-popover] — otherwise a mousedown on an option looks like an
+          outside click to the ancestor and closes it before onSelect commits. */}
       {open &&
         createPortal(
           <div
             ref={popupRef}
+            data-cf-popover=""
             style={popupStyle}
             className="pop-in flex flex-col overflow-hidden rounded-md border border-[var(--color-border-2)] bg-[var(--color-surface-2)] shadow-2xl"
           >

--- a/src/renderer/src/hooks/useTimeline.ts
+++ b/src/renderer/src/hooks/useTimeline.ts
@@ -19,6 +19,7 @@ import {
   computeZoomAtPointer,
   computeWheelScroll,
   clampZoom,
+  timeRangeToRect,
 } from '../lib/timelineMath'
 
 const RULER_H = 20
@@ -77,6 +78,10 @@ interface UseTimelineOptions {
   /** Called when zoom or scroll changes so the caller can sync other views. */
   onZoomChange?: (zoom: number, scrollT: number) => void
   onScrollChange?: (scrollT: number, zoom: number) => void
+  /** Double-click on a word in the open word lane. rect = word's on-screen box (viewport coords). */
+  onWordDoubleClick?: (segId: string, wordIdx: number, rect: DOMRect) => void
+  /** Double-click on a group block in the segment track. rect = group's on-screen box (viewport coords). */
+  onGroupDoubleClick?: (segId: string, rect: DOMRect) => void
 }
 
 interface TimelineState {
@@ -100,6 +105,8 @@ export function useTimeline({
   onHover,
   onZoomChange,
   onScrollChange,
+  onWordDoubleClick,
+  onGroupDoubleClick,
 }: UseTimelineOptions) {
   // Zoom + scroll are mutable refs — we don't need React re-renders when they change,
   // the draw function reads them directly.
@@ -684,6 +691,62 @@ export function useTimeline({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onHover])
 
+  // Phase 1 (timeline-inline-editing): double-click → word/group popup hooks.
+  // Reports hits only — no popup/UI lives here, mirroring every other callback above.
+  const onDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      // A drag in flight is never a double-click. movedRef deliberately not checked: it
+      // can be tripped by sub-slop drift on the pair's second click (it is never reset
+      // on mouseup), and the browser's own dblclick movement threshold already gates
+      // large movements.
+      if (dragRef.current || wordDragRef.current) return
+
+      const canvas = canvasRef.current
+      if (!canvas || !duration) return
+      const rect = canvas.getBoundingClientRect()
+      const { zoom, scrollT } = stateRef.current
+      const pps = computePixelsPerSecond(rect.width, duration / zoom)
+
+      // Word lane wins, same priority as onMouseDown.
+      const wordHit = findWordHit(e.clientX, e.clientY)
+      if (wordHit) {
+        if (wordHit.edge === 'body' && selectedSegId) {
+          const seg = segments.find((s) => s.id === selectedSegId)
+          const word = seg?.words[wordHit.wordIdx]
+          if (seg && word) {
+            const { x, w } = timeRangeToRect(
+              word.start,
+              word.end,
+              rect.left,
+              rect.width,
+              scrollT,
+              pps
+            )
+            onWordDoubleClick?.(
+              selectedSegId,
+              wordHit.wordIdx,
+              new DOMRect(x, rect.top + TOTAL_H, w, WORD_TRACK_H)
+            )
+          }
+        }
+        return
+      }
+      // Empty lane space never falls through to the group track behind it.
+      if (isInWordLane(e.clientY)) return
+
+      const hit = findEdge(e.clientX)
+      if (hit && hit.edge === 'body') {
+        const seg = segments.find((s) => s.id === hit.segId)
+        if (seg) {
+          const { x, w } = timeRangeToRect(seg.start, seg.end, rect.left, rect.width, scrollT, pps)
+          onGroupDoubleClick?.(hit.segId, new DOMRect(x, rect.top + RULER_H, w, TRACK_H))
+        }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [segments, duration, selectedSegId, onWordDoubleClick, onGroupDoubleClick]
+  )
+
   // Wheel handling must use a native listener with { passive: false } so that
   // preventDefault() actually stops the page from scrolling/zooming. React's
   // onWheel JSX prop is registered as passive in modern Chrome and would log
@@ -733,7 +796,16 @@ export function useTimeline({
     stateRef.current.scrollT = Math.max(0, scrollT)
   }, [])
 
-  return { draw, onMouseDown, onMouseMove, onMouseUp, onMouseLeave, setZoom, setScroll }
+  return {
+    draw,
+    onMouseDown,
+    onMouseMove,
+    onMouseUp,
+    onMouseLeave,
+    onDoubleClick,
+    setZoom,
+    setScroll,
+  }
 }
 
 // ── Helpers ────────────────────────────────────────────────────────

--- a/src/renderer/src/hooks/useTimeline.ts
+++ b/src/renderer/src/hooks/useTimeline.ts
@@ -78,10 +78,10 @@ interface UseTimelineOptions {
   /** Called when zoom or scroll changes so the caller can sync other views. */
   onZoomChange?: (zoom: number, scrollT: number) => void
   onScrollChange?: (scrollT: number, zoom: number) => void
-  /** Double-click on a word in the open word lane. rect = word's on-screen box (viewport coords). */
-  onWordDoubleClick?: (segId: string, wordIdx: number, rect: DOMRect) => void
-  /** Double-click on a group block in the segment track. rect = group's on-screen box (viewport coords). */
-  onGroupDoubleClick?: (segId: string, rect: DOMRect) => void
+  /** Right-click on a word in the open word lane. rect = word's on-screen box (viewport coords). */
+  onWordContextMenu?: (segId: string, wordIdx: number, rect: DOMRect) => void
+  /** Right-click on a group block in the segment track. rect = group's on-screen box (viewport coords). */
+  onGroupContextMenu?: (segId: string, rect: DOMRect) => void
 }
 
 interface TimelineState {
@@ -105,8 +105,8 @@ export function useTimeline({
   onHover,
   onZoomChange,
   onScrollChange,
-  onWordDoubleClick,
-  onGroupDoubleClick,
+  onWordContextMenu,
+  onGroupContextMenu,
 }: UseTimelineOptions) {
   // Zoom + scroll are mutable refs — we don't need React re-renders when they change,
   // the draw function reads them directly.
@@ -464,6 +464,9 @@ export function useTimeline({
 
   const onMouseDown = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
+      // Right-click (and middle-click) opens a context menu now, not a drag/select —
+      // only the left button starts a drag or the click-to-select path below.
+      if (e.button !== 0) return
       movedRef.current = false
 
       // Word lane wins: grabbing a word must never fall through to the segment.
@@ -664,6 +667,10 @@ export function useTimeline({
 
   const onMouseUp = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
+      // A right/middle-button release never started a drag (onMouseDown returns
+      // early for it), so without this guard it would fall into the "not
+      // dragging" branch below and seek + deselect right under the context menu.
+      if (e.button !== 0) return
       const segDrag = dragRef.current
       const wasDragging = !!segDrag || !!wordDragRef.current
       dragRef.current = null
@@ -691,14 +698,15 @@ export function useTimeline({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onHover])
 
-  // Phase 1 (timeline-inline-editing): double-click → word/group popup hooks.
+  // Phase 1 (timeline-inline-editing): right-click (contextmenu) → word/group popup hooks.
   // Reports hits only — no popup/UI lives here, mirroring every other callback above.
-  const onDoubleClick = useCallback(
+  const onContextMenu = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
-      // A drag in flight is never a double-click. movedRef deliberately not checked: it
-      // can be tripped by sub-slop drift on the pair's second click (it is never reset
-      // on mouseup), and the browser's own dblclick movement threshold already gates
-      // large movements.
+      // Suppress the native context menu whenever the cursor is over the timeline
+      // canvas — even on a miss, a native menu here is just noise.
+      e.preventDefault()
+
+      // A drag in flight is never a context-menu open.
       if (dragRef.current || wordDragRef.current) return
 
       const canvas = canvasRef.current
@@ -722,7 +730,7 @@ export function useTimeline({
               scrollT,
               pps
             )
-            onWordDoubleClick?.(
+            onWordContextMenu?.(
               selectedSegId,
               wordHit.wordIdx,
               new DOMRect(x, rect.top + TOTAL_H, w, WORD_TRACK_H)
@@ -739,12 +747,12 @@ export function useTimeline({
         const seg = segments.find((s) => s.id === hit.segId)
         if (seg) {
           const { x, w } = timeRangeToRect(seg.start, seg.end, rect.left, rect.width, scrollT, pps)
-          onGroupDoubleClick?.(hit.segId, new DOMRect(x, rect.top + RULER_H, w, TRACK_H))
+          onGroupContextMenu?.(hit.segId, new DOMRect(x, rect.top + RULER_H, w, TRACK_H))
         }
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     },
-    [segments, duration, selectedSegId, onWordDoubleClick, onGroupDoubleClick]
+    [segments, duration, selectedSegId, onWordContextMenu, onGroupContextMenu]
   )
 
   // Wheel handling must use a native listener with { passive: false } so that
@@ -802,7 +810,7 @@ export function useTimeline({
     onMouseMove,
     onMouseUp,
     onMouseLeave,
-    onDoubleClick,
+    onContextMenu,
     setZoom,
     setScroll,
   }

--- a/src/renderer/src/lib/timelineMath.test.ts
+++ b/src/renderer/src/lib/timelineMath.test.ts
@@ -10,6 +10,7 @@ import {
   computeZoomAtPointer,
   computeWheelScroll,
   clampZoom,
+  timeRangeToRect,
 } from './timelineMath'
 
 // ── niceStep ─────────────────────────────────────────────────────
@@ -234,5 +235,34 @@ describe('clampZoom', () => {
 
   test('floors a negative zoom to 1', () => {
     expect(clampZoom(-10)).toBe(1)
+  })
+})
+
+// ── timeRangeToRect ──────────────────────────────────────────────
+
+describe('timeRangeToRect', () => {
+  // rectLeft=0, rectWidth=800, scrollT=5, pps=80 -> visible window [5,15]
+  test('computes x/w for a range fully inside the visible window', () => {
+    expect(timeRangeToRect(10, 12, 0, 800, 5, 80)).toEqual({ x: 400, w: 160 })
+  })
+
+  test('offsets by a non-zero rectLeft', () => {
+    expect(timeRangeToRect(10, 12, 50, 800, 5, 80)).toEqual({ x: 450, w: 160 })
+  })
+
+  test('clamps the start edge to rectLeft when startT is scrolled off-screen left', () => {
+    expect(timeRangeToRect(2, 6, 0, 800, 5, 80)).toEqual({ x: 0, w: 80 })
+  })
+
+  test('clamps the end edge to the right side of the rect when endT overflows', () => {
+    expect(timeRangeToRect(14, 20, 0, 800, 5, 80)).toEqual({ x: 720, w: 80 })
+  })
+
+  test('returns zero width (never negative) when the range is entirely off-screen right', () => {
+    expect(timeRangeToRect(20, 22, 0, 800, 5, 80)).toEqual({ x: 800, w: 0 })
+  })
+
+  test('returns zero width (never negative) when the range is entirely off-screen left', () => {
+    expect(timeRangeToRect(-5, -2, 0, 800, 5, 80)).toEqual({ x: 0, w: 0 })
   })
 })

--- a/src/renderer/src/lib/timelineMath.ts
+++ b/src/renderer/src/lib/timelineMath.ts
@@ -108,3 +108,24 @@ export function computeWheelScroll(
 export function clampZoom(zoom: number): number {
   return Math.max(1, zoom)
 }
+
+/** Viewport x/width for a [startT, endT] time range, clamped to the canvas's
+ *  client rect. Reuses the exact `timeToPixel` conversion the hit-test
+ *  functions use so a double-click popup's anchor rect can never drift from
+ *  what findEdge()/findWordHit() consider a hit. */
+export function timeRangeToRect(
+  startT: number,
+  endT: number,
+  rectLeft: number,
+  rectWidth: number,
+  scrollT: number,
+  pps: number
+): { x: number; w: number } {
+  const rawStartX = timeToPixel(startT, scrollT, pps) + rectLeft
+  const rawEndX = timeToPixel(endT, scrollT, pps) + rectLeft
+  const min = rectLeft
+  const max = rectLeft + rectWidth
+  const x = Math.max(min, Math.min(rawStartX, max))
+  const endX = Math.max(min, Math.min(rawEndX, max))
+  return { x, w: Math.max(endX - x, 0) }
+}


### PR DESCRIPTION
## Summary

- Right-click a word in the timeline's word lane opens `WordStylePopup` with a new text-correction field plus all existing per-word style overrides (font size scale, color, etc.) — anchored to the word's on-screen rect.
- Right-click a group block in the segment track opens `GroupPositionPopup` for a per-group position override, routed through the existing position-only path — this never flips `groupsEdited`, so automatic re-grouping keeps working.
- New `timeRangeToRect` helper in `lib/timelineMath.ts` (unit-tested) computes on-screen rects for both hit types.
- Lazy one-undo-snapshot-per-popup-session pattern (mirrors the drag-start convention already used elsewhere) instead of pushing undo on every keystroke/slider tick.
- Stale-index guards so a popup never edits the wrong word/group if the underlying groups array changes while it's open.
- Trigger changed from double-click to right-click (`contextmenu`) after in-review feedback that double-click was clunky and raced the click-to-select toggle. `onMouseDown`/`onMouseUp` are now left-button only so a right-click can't start a drag or fall through to the seek/deselect path underneath the popup. Callbacks/props renamed accordingly: `onWordContextMenu`/`onGroupContextMenu`.

## Test plan

Automated:
- [x] `npm run typecheck` clean
- [x] Frontend tests: 304/304 passing (8 new, incl. `timelineMath.test.ts` and `WordStylePopup.test.tsx`)

Manual QA (not yet done):
- [ ] Right-click a word in the timeline word lane opens the popup; text correction field edits the word text
- [ ] Right-click a word applies each per-word style override and it reflects live in the canvas preview
- [ ] Right-click a group block opens the position popup; position override applies and persists
- [ ] Drag/snap/seek/zoom on the timeline still work normally (no regression from the left-button-only guard)
- [ ] Cmd+Z undoes a popup session's edits in one step
- [ ] Light theme: both popups render legibly
- [ ] Verify a per-word/group override reaches the exported render (not just the canvas preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSAhHzvLLbsfLgCGw7eyvv